### PR TITLE
Adjust save management documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ Currently, up to version 1.6.2.4 is supported. Newer versions of the game may or
 - UFO 50 must have a save on your device. This means you must have started the game at least once before you attempt to upload your saves.
 
 ### Backup (Android -> Computer)
-This will copy your save files from your device and put them in the save folder.
+Run one of the following scripts to copy your save files from your device and into the save folder.
 - Windows: run `backup_saves_windows.bat`
 - Linux: run `backup_saves_linux`
 
 ### Restoration (Computer -> Android)
-To restore your save, place your save files into the save folder and run restore_saves_windows.bat if you're using Windows or restore_saves_unix if you're not.
+To restore your save, place your save files into the save folder and run one of the following scripts
 - Windows: run `upload_saves_windows.bat`
 - Linux: run `upload_saves_linux`
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ pirating it would be a serious dick move. Don't screw over indie developers.
 Currently, up to version 1.6.2.4 is supported. Newer versions of the game may or may not work.
 
 ## Building
-0. Purchase UFO 50. The devs deserve the money.
+1. [Purchase UFO 50](https://store.steampowered.com/app/1147860/UFO_50/). The devs deserve the money.
 1. Copy your UFO 50 game files into the ufo50 folder.
 2. Run build_windows.bat if you're using Windows, build_unix if you're not.
 3. Copy com.unofficial.ufo50.apk to your device.
@@ -18,10 +18,19 @@ Currently, up to version 1.6.2.4 is supported. Newer versions of the game may or
 6. Play! You can press Start, go to Settings > Video Settings, and set SCALE to FILL to fill the entire screen.
 
 ## Save Management
-Before you can manage save files, make sure you have enabled Developer Options on your device and allowed USB or Wi-Fi debugging. Make sure you have run UFO 50 at least once before you attempt to upload your saves.
-To backup your save, run `backup_saves_windows.bat` if you're using Windows or `backup_saves_linux` if you're not.
+### Prerequisites
+- Developer Options must be enabled and USB or Wi-Fi debugging must be allowed on your device.
+- UFO 50 must have a save on your device. This means you must have started the game at least once before you attempt to upload your saves.
+
+### Backup (Android -> Computer)
 This will copy your save files from your device and put them in the save folder.
-To restore your save, place your save files into the save folder and run `upload_saves_windows.bat` if you're using Windows or `upload_saves_linux` if you're not.
+- Windows: run `backup_saves_windows.bat`
+- Linux: run `backup_saves_linux`
+
+### Restoration (Computer -> Android)
+To restore your save, place your save files into the save folder and run restore_saves_windows.bat if you're using Windows or restore_saves_unix if you're not.
+- Windows: run `upload_saves_windows.bat`
+- Linux: run `upload_saves_linux`
 
 ## Notes
 If you have UFO 50 working on PortMaster, open ufo50.port in an archive manager like 7-zip and use the game.droid and options.ini files in that directory.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Currently, up to version 1.6.2.4 is supported. Newer versions of the game may or
 
 ## Save Management
 Before you can manage save files, make sure you have enabled Developer Options on your device and allowed USB or Wi-Fi debugging. Make sure you have run UFO 50 at least once before you attempt to upload your saves.
-To backup your save, run backup_saves_windows.bat if you're using Windows or backup_saves_unix if you're not.
+To backup your save, run `backup_saves_windows.bat` if you're using Windows or `backup_saves_linux` if you're not.
 This will copy your save files from your device and put them in the save folder.
-To restore your save, place your save files into the save folder and run restore_saves_windows.bat if you're using Windows or restore_saves_unix if you're not.
+To restore your save, place your save files into the save folder and run `upload_saves_windows.bat` if you're using Windows or `upload_saves_linux` if you're not.
 
 ## Notes
 If you have UFO 50 working on PortMaster, open ufo50.port in an archive manager like 7-zip and use the game.droid and options.ini files in that directory.


### PR DESCRIPTION
When using the docs to perform my migration, I noticed that the names were mismatched between the files. This PR addresses those changes.

## Summary of changes
1. Fixed names for the restoration section to match the filenames: `restore_*` to `upload_*`
3. Fixed the names for both Linux save scripts: `*_unix` to `*_linux`
4. Added formatting to "Save Management" section
5. Adjusted numbering in "Build" section to allow for auto-numbering to take over
6. Added newline to end of file in accordance with best practices

Please let me know if you would like me to adjust any of these changes or split them into separate PRs.