### PR TITLE
fix: support latest UFO 50 builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 
 bin/java
+bin/utmt
+com.unofficial.ufo50.apk
+smoke/

--- a/README.md
+++ b/README.md
@@ -7,22 +7,61 @@ Please do not share your APK with others. Mossmouth created an incredible game a
 pirating it would be a serious dick move. Don't screw over indie developers.
 
 Current UFO 50 releases are supported by dynamically packaging the game data files that ship with your local copy.
-The default Android wrapper uses GameMaker runtime 2024.1400.4.968 for compatibility with the current Steam build, and includes a controller hotplug patch so Bluetooth controllers can be detected after the app is already open.
+The default Android wrapper uses GameMaker runtime 2024.1400.4.968 for compatibility with the current Steam build, includes a controller hotplug patch so Bluetooth controllers can be detected after the app is already open, and targets Android 9/API 28 while supporting Android 5.0+ devices.
 
 ## Building
-0. Purchase UFO 50. The devs deserve the money.
-1. Copy your UFO 50 game files into the ufo50 folder, or pass the game directory to the build script.
-2. Run `build_windows.bat` if you're using Windows, `build_linux` on Linux, or `build_macos.sh` on macOS. For example: `./build_linux /path/to/UFO50`.
-3. Copy com.unofficial.ufo50.apk to your device.
-4. Enable installing from unofficial sources on your device, if needed. This will vary from device to device.
-5. Install com.unofficial.ufo50.apk with your file manager of choice. You can delete it after it's installed.
-6. Play! You can press Start, go to Settings > Video Settings, and set SCALE to FILL to fill the entire screen.
+0. Purchase and install UFO 50. The devs deserve the money.
+1. Download or clone this repo.
+2. Find your UFO 50 install folder. It must contain `data.win` and `options.ini`.
+3. Run the build script for your computer:
+
+### Windows
+Double-click `build_windows.bat`, or open Command Prompt in this repo and run:
+
+```bat
+build_windows.bat "C:\Program Files (x86)\Steam\steamapps\common\UFO 50"
+```
+
+If you omit the path, copy/merge your UFO 50 files into this repo's `ufo50` folder first, then run `build_windows.bat`.
+
+### Linux
+Open a terminal in this repo and run:
+
+```sh
+chmod +x build_linux
+./build_linux "$HOME/.steam/steam/steamapps/common/UFO 50"
+```
+
+If your Steam library is somewhere else, replace the path with your UFO 50 install folder. The Linux script requires `wget`, `unzip`, and `python3`; install them with your distro's package manager if the script reports they are missing.
+
+### macOS
+Open Terminal in this repo and run:
+
+```sh
+chmod +x build_macos.sh
+./build_macos.sh "$HOME/Library/Application Support/Steam/steamapps/common/UFO 50"
+```
+
+If your Steam library is somewhere else, replace the path with your UFO 50 install folder. The macOS script requires `wget`, `unzip`, and `python3`; if `wget` is missing, install it with Homebrew: `brew install wget`.
+
+After the script finishes:
+1. Copy `com.unofficial.ufo50.apk` to your Android device.
+2. Enable installing from unofficial sources on your device, if needed. This varies from device to device.
+3. Install `com.unofficial.ufo50.apk` with your file manager of choice. You can delete the APK file after it's installed.
+4. Play! You can press Start, go to Settings > Video Settings, and set SCALE to FILL to fill the entire screen.
+
+If you copy files manually, merge/replace the whole UFO 50 install into `ufo50/` instead of skipping duplicates. The build needs the current `data.win`, `options.ini`, `*.dat`, `Textures/`, `ext/`, and `fonts/` files from your installed game.
+
+## Troubleshooting
+- **Crash immediately after the cover art/splash screen:** rebuild from a fresh checkout or pull the latest version of this repo. Older builds targeted a newer Android SDK and could crash on handhelds such as MagicX Mini Zero 28/Android 10 or MagicX One35/Android 12.
+- **"Error parsing the package":** delete the old APK from the device, rebuild, copy the new `com.unofficial.ufo50.apk`, and install that file again. If Android still rejects it, confirm the downloaded/copied APK size matches the one on your computer and that the device is running Android 5.0 or newer.
+- **Missing text/audio/textures or startup crashes after replacing files:** make sure you did not skip duplicate files when copying the game directory. Re-copy the game files and choose replace/merge, or pass the game install path directly to the build script.
 
 ## Save Management
 Before you can manage save files, make sure you have enabled Developer Options on your device and allowed USB or Wi-Fi debugging. Make sure you have run UFO 50 at least once before you attempt to upload your saves.
-To backup your save, run backup_saves_windows.bat if you're using Windows or backup_saves_unix if you're not.
+To backup your save, run `backup_saves_windows.bat` on Windows, `backup_saves_linux` on Linux, or `backup_saves_macos.sh` on macOS.
 This will copy your save files from your device and put them in the save folder.
-To restore your save, place your save files into the save folder and run restore_saves_windows.bat if you're using Windows or restore_saves_unix if you're not.
+To upload/restore your save, place your save files into the save folder and run `upload_saves_windows.bat` on Windows, `upload_saves_linux` on Linux, or `upload_saves_macos.sh` on macOS.
 
 ## Notes
 If you have UFO 50 working on PortMaster, open ufo50.port in an archive manager like 7-zip and use the game.droid and options.ini files in that directory.

--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ It's an extremely simple process to build your own copy and get it running.
 Please do not share your APK with others. Mossmouth created an incredible game and
 pirating it would be a serious dick move. Don't screw over indie developers.
 
-Currently, up to version 1.6.2.4 is supported. Newer versions of the game may or may not work.
+Current UFO 50 releases are supported by dynamically packaging the game data files that ship with your local copy.
+The default Android wrapper uses GameMaker runtime 2024.1400.4.968 for compatibility with the current Steam build, and includes a controller hotplug patch so Bluetooth controllers can be detected after the app is already open.
 
 ## Building
 0. Purchase UFO 50. The devs deserve the money.
-1. Copy your UFO 50 game files into the ufo50 folder.
-2. Run build_windows.bat if you're using Windows, build_unix if you're not.
+1. Copy your UFO 50 game files into the ufo50 folder, or pass the game directory to the build script.
+2. Run `build_windows.bat` if you're using Windows, `build_linux` on Linux, or `build_macos.sh` on macOS. For example: `./build_linux /path/to/UFO50`.
 3. Copy com.unofficial.ufo50.apk to your device.
 4. Enable installing from unofficial sources on your device, if needed. This will vary from device to device.
 5. Install com.unofficial.ufo50.apk with your file manager of choice. You can delete it after it's installed.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Please do not share your APK with others. Mossmouth created an incredible game a
 pirating it would be a serious dick move. Don't screw over indie developers.
 
 Current UFO 50 releases are supported by dynamically packaging the game data files that ship with your local copy.
-The default Android wrapper uses GameMaker runtime 2024.1400.4.968 for compatibility with the current Steam build, includes a controller hotplug patch so Bluetooth controllers can be detected after the app is already open, and targets Android 9/API 28 while supporting Android 5.0+ devices.
+The default Android wrapper uses GameMaker runtime 2024.1400.4.968 for compatibility with the current Steam build, includes a controller hotplug patch so Bluetooth controllers can be detected after the app is already open, and is built to run on Android 5.0+ devices, including Android 10/12 handhelds.
 
 ## Building
 0. Purchase and install UFO 50. The devs deserve the money.
@@ -53,7 +53,7 @@ After the script finishes:
 If you copy files manually, merge/replace the whole UFO 50 install into `ufo50/` instead of skipping duplicates. The build needs the current `data.win`, `options.ini`, `*.dat`, `Textures/`, `ext/`, and `fonts/` files from your installed game.
 
 ## Troubleshooting
-- **Crash immediately after the cover art/splash screen:** rebuild from a fresh checkout or pull the latest version of this repo. Older builds targeted a newer Android SDK and could crash on handhelds such as MagicX Mini Zero 28/Android 10 or MagicX One35/Android 12.
+- **Crash immediately after the cover art/splash screen:** rebuild from a fresh checkout or pull the latest version of this repo. The current wrapper is built for Android 5.0+ compatibility, including handhelds such as MagicX Mini Zero 28/Android 10 and MagicX One35/Android 12.
 - **"Error parsing the package":** delete the old APK from the device, rebuild, copy the new `com.unofficial.ufo50.apk`, and install that file again. If Android still rejects it, confirm the downloaded/copied APK size matches the one on your computer and that the device is running Android 5.0 or newer.
 - **Missing text/audio/textures or startup crashes after replacing files:** make sure you did not skip duplicate files when copying the game directory. Re-copy the game files and choose replace/merge, or pass the game install path directly to the build script.
 

--- a/build_linux
+++ b/build_linux
@@ -1,29 +1,43 @@
 #!/bin/bash
+set -euo pipefail
 
-if ! command -v wget 2>&1 >/dev/null; then
+if ! command -v wget >/dev/null 2>&1; then
     echo "ERROR: Missing prerequisite: wget"
     exit 1
 fi
 
-if ! command -v unzip 2>&1 >/dev/null; then
+if ! command -v unzip >/dev/null 2>&1; then
     echo "ERROR: Missing prerequisite: unzip"
     exit 1
 fi
 
-# Linux: https://corretto.aws/downloads/resources/21.0.2.13.1/amazon-corretto-21.0.2.13.1-linux-x64-jdk.zip
-# OSX: https://corretto.aws/downloads/resources/21.0.5.11.1/amazon-corretto-21.0.5.11.1-macosx-x64.tar.gz
+UFO50_SOURCE="${1:-${UFO50_SOURCE:-./ufo50}}"
+WRAPPER_APK="${UFO50_WRAPPER_APK:-./base/AndroidWrapper2024.1400.4.968_VM_debug_gamepad_hotplug.apk}"
+AAPT="./bin/aapt-linux"
+ZIPALIGN="./bin/zipalign"
+JAVA="./bin/java/bin/java"
+OUTPUT_APK="com.unofficial.ufo50.apk"
 
 # Make sure that we actually have game files first
-if [ ! -f ./ufo50/data.win ]; then
-	echo "Place your UFO 50 game files in the ufo50 folder first!"
-	read -n 1 -s -r -p "Press any key to continue..."
-	echo
-	exit 1
+if [ ! -f "${UFO50_SOURCE}/data.win" ]; then
+    echo "Place your UFO 50 game files in ${UFO50_SOURCE} first, pass the path as the first argument, or set UFO50_SOURCE."
+    if [ -t 0 ]; then read -n 1 -s -r -p "Press any key to continue..."; echo; fi
+    exit 1
+fi
+
+if [ ! -f "${UFO50_SOURCE}/options.ini" ]; then
+    echo "ERROR: Missing ${UFO50_SOURCE}/options.ini"
+    exit 1
+fi
+
+if [ ! -f "${WRAPPER_APK}" ]; then
+    echo "ERROR: Missing wrapper APK: ${WRAPPER_APK}"
+    exit 1
 fi
 
 # Permissions
-chmod +x ./bin/zipalign
-chmod +x ./bin/aapt-linux
+chmod +x "${ZIPALIGN}"
+chmod +x "${AAPT}"
 
 # Clean up from any previous runs
 rm -f ./UFO50Wrapper.apk
@@ -31,95 +45,150 @@ rm -f ./com.unofficial.ufo50.zip
 rm -rf ./assets
 mkdir ./assets
 
-# Copy required assets
-echo "Preparing assets..."
-cp -r ./ufo50/ext ./assets/ext
-cp -r ./ufo50/Textures ./assets/Textures
-cp ./ufo50/*.dat ./assets/
-cp ./ufo50/options.ini ./assets/
-cp ./ufo50/data.win ./assets/game.droid
-cp ./base/AndroidWrapper2024.8.0.216_VM_debug.apk ./UFO50Wrapper.apk
+# Copy required assets. Keep this discovery-based so new UFO 50 releases work when
+# texture groups, audio groups, fonts, or localization files are added/removed.
+echo "Preparing assets from ${UFO50_SOURCE}..."
+[ ! -d "${UFO50_SOURCE}/ext" ] || cp -R "${UFO50_SOURCE}/ext" ./assets/ext
+[ ! -d "${UFO50_SOURCE}/Textures" ] || cp -R "${UFO50_SOURCE}/Textures" ./assets/Textures
+[ ! -d "${UFO50_SOURCE}/fonts" ] || cp -R "${UFO50_SOURCE}/fonts" ./assets/fonts
+shopt -s nullglob
+cp "${UFO50_SOURCE}"/*.dat ./assets/
+shopt -u nullglob
+cp "${UFO50_SOURCE}/options.ini" ./assets/
+cp "${UFO50_SOURCE}/data.win" ./assets/game.droid
+cp "${WRAPPER_APK}" ./UFO50Wrapper.apk
+
+# Android APK assets are case-sensitive, while the GameMaker runtime lowercases
+# datafile paths (for example ext/english/0_text.json and textures/*.yytex).
+# Normalize staged sidecar assets to lowercase paths so they can be found.
+python3 - <<'PY'
+from pathlib import Path
+import shutil
+
+root = Path('./assets')
+tmp = Path('./assets.lowercase')
+if tmp.exists():
+    shutil.rmtree(tmp)
+tmp.mkdir()
+
+for path in root.rglob('*'):
+    rel = path.relative_to(root)
+    lower_rel = Path(*[part.lower() for part in rel.parts])
+    dest = tmp / lower_rel
+    if path.is_dir():
+        dest.mkdir(parents=True, exist_ok=True)
+    else:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, dest)
+
+shutil.rmtree(root)
+tmp.rename(root)
+PY
+
+# Some current PC builds have trailing bytes after the GameMaker FORM chunk.
+# The Android runner rejects those with "unexpected size", so trim game.droid
+# to the FORM header size when needed.
+python3 - <<'PY'
+from pathlib import Path
+path = Path('./assets/game.droid')
+with path.open('rb') as fh:
+    header = fh.read(8)
+if len(header) != 8 or header[:4] != b'FORM':
+    raise SystemExit('ERROR: assets/game.droid is not a GameMaker FORM file')
+expected = int.from_bytes(header[4:8], 'little') + 8
+actual = path.stat().st_size
+if actual > expected:
+    print(f'Trimming game.droid from {actual} to FORM size {expected} bytes')
+    with path.open('r+b') as fh:
+        fh.truncate(expected)
+elif actual < expected:
+    raise SystemExit(f'ERROR: game.droid is smaller than FORM header size ({actual} < {expected})')
+
+PY
+
+# The PC data has a Steamworks extension, but its Android class name is blank.
+# GameMaker then looks for com.unofficial.ufo50. and never calls our Android
+# stub. Patch the EXTN metadata so Steamworks calls are routed to
+# com.unofficial.ufo50.Steamworks.
+UTMT_CLI="${UTMT_CLI:-./bin/utmt/UndertaleModCli}"
+if [ ! -x "${UTMT_CLI}" ]; then
+    echo "Downloading UndertaleModCli..."
+    rm -rf ./bin/utmt ./utmt.zip
+    mkdir -p ./bin/utmt
+    wget https://github.com/UnderminersTeam/UndertaleModTool/releases/download/0.9.1.0/UTMT_CLI_v0.9.1.0-Ubuntu.zip -O ./utmt.zip
+    unzip -q ./utmt.zip -d ./bin/utmt
+    rm -f ./utmt.zip
+    chmod +x "${UTMT_CLI}"
+fi
+
+echo "Patching Steamworks extension metadata for Android..."
+"${UTMT_CLI}" load ./assets/game.droid -s ./scripts/patch_ufo50_android.csx -o ./assets/game.droid.patched
+mv ./assets/game.droid.patched ./assets/game.droid
 
 # Download Java, if needed
-if [ ! -f ./bin/java/bin/java ]; then
-	rm -rf ./bin/java
-	echo "Downloading java..."
-	wget https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-linux-x64.tar.gz -O ./jdk.tar.gz
-	echo "Extracting java..."
-	tar -zxvf ./jdk.tar.gz
-	mv ./amazon-corretto-21.0.6.7.1-linux-x64 ./bin/java
-	rm -f ./jdk.tar.gz
+if [ ! -f "${JAVA}" ]; then
+    rm -rf ./bin/java
+    echo "Downloading java..."
+    wget https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-linux-x64.tar.gz -O ./jdk.tar.gz
+    echo "Extracting java..."
+    tar -zxvf ./jdk.tar.gz
+    mv ./amazon-corretto-21.0.6.7.1-linux-x64 ./bin/java
+    rm -f ./jdk.tar.gz
 fi
 
 # Clean wrapper apk
+# The base wrapper contains placeholder game.droid/options.ini; replace them.
 echo "Preparing wrapper..."
-./bin/aapt-linux remove -f -v UFO50Wrapper.apk assets/options.ini
-./bin/aapt-linux remove -f -v UFO50Wrapper.apk assets/game.droid
+"${AAPT}" remove -f -v UFO50Wrapper.apk assets/options.ini || true
+"${AAPT}" remove -f -v UFO50Wrapper.apk assets/game.droid || true
+
+add_assets() {
+    local batch=()
+    local file
+    while IFS= read -r file; do
+        batch+=("${file}")
+        if [ "${#batch[@]}" -ge 80 ]; then
+            "${AAPT}" add -f -v UFO50Wrapper.apk "${batch[@]}"
+            batch=()
+        fi
+    done < <(find assets -type f | LC_ALL=C sort)
+
+    if [ "${#batch[@]}" -gt 0 ]; then
+        "${AAPT}" add -f -v UFO50Wrapper.apk "${batch[@]}"
+    fi
+}
 
 # Add game assets to base wrapper APK
 echo "Building wrapper..."
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/audiogroup1.dat assets/audiogroup2.dat assets/audiogroup3.dat assets/audiogroup4.dat assets/audiogroup5.dat assets/audiogroup6.dat assets/audiogroup7.dat assets/audiogroup8.dat assets/audiogroup9.dat
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/audiogroup10.dat assets/audiogroup11.dat assets/audiogroup12.dat assets/audiogroup13.dat assets/audiogroup14.dat assets/audiogroup15.dat assets/audiogroup16.dat assets/audiogroup17.dat assets/audiogroup18.dat assets/audiogroup19.dat
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/audiogroup20.dat assets/audiogroup21.dat assets/audiogroup22.dat assets/audiogroup23.dat assets/audiogroup24.dat assets/audiogroup25.dat assets/audiogroup26.dat assets/audiogroup27.dat assets/audiogroup28.dat assets/audiogroup29.dat
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/audiogroup30.dat assets/audiogroup31.dat assets/audiogroup32.dat assets/audiogroup33.dat assets/audiogroup34.dat assets/audiogroup35.dat assets/audiogroup36.dat assets/audiogroup37.dat assets/audiogroup38.dat assets/audiogroup39.dat
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/audiogroup40.dat assets/audiogroup41.dat assets/audiogroup43.dat assets/audiogroup44.dat assets/audiogroup45.dat assets/audiogroup46.dat assets/audiogroup47.dat assets/audiogroup48.dat assets/audiogroup49.dat
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/audiogroup50.dat assets/audiogroup51.dat assets/audiogroup52.dat assets/audiogroup53.dat
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/ENGLISH/0_Text.json assets/ext/ENGLISH/1_Text.json assets/ext/ENGLISH/2_Text.json assets/ext/ENGLISH/3_Text.json assets/ext/ENGLISH/4_Text.json assets/ext/ENGLISH/5_Text.json assets/ext/ENGLISH/6_Text.json assets/ext/ENGLISH/7_Text.json assets/ext/ENGLISH/8_Text.json assets/ext/ENGLISH/9_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/ENGLISH/10_Text.json assets/ext/ENGLISH/11_Text.json assets/ext/ENGLISH/12_Text.json assets/ext/ENGLISH/13_Text.json assets/ext/ENGLISH/14_Text.json assets/ext/ENGLISH/15_Text.json assets/ext/ENGLISH/16_Text.json assets/ext/ENGLISH/17_Text.json assets/ext/ENGLISH/18_Text.json assets/ext/ENGLISH/19_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/ENGLISH/20_Text.json assets/ext/ENGLISH/21_Text.json assets/ext/ENGLISH/22_Text.json assets/ext/ENGLISH/23_Text.json assets/ext/ENGLISH/24_Text.json assets/ext/ENGLISH/25_Text.json assets/ext/ENGLISH/26_Text.json assets/ext/ENGLISH/27_Text.json assets/ext/ENGLISH/28_Text.json assets/ext/ENGLISH/29_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/ENGLISH/30_Text.json assets/ext/ENGLISH/31_Text.json assets/ext/ENGLISH/32_Text.json assets/ext/ENGLISH/33_Text.json assets/ext/ENGLISH/34_Text.json assets/ext/ENGLISH/35_Text.json assets/ext/ENGLISH/36_Text.json assets/ext/ENGLISH/37_Text.json assets/ext/ENGLISH/38_Text.json assets/ext/ENGLISH/39_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/ENGLISH/40_Text.json assets/ext/ENGLISH/41_Text.json assets/ext/ENGLISH/42_Text.json assets/ext/ENGLISH/43_Text.json assets/ext/ENGLISH/44_Text.json assets/ext/ENGLISH/45_Text.json assets/ext/ENGLISH/46_Text.json assets/ext/ENGLISH/47_Text.json assets/ext/ENGLISH/48_Text.json assets/ext/ENGLISH/49_Text.json assets/ext/ENGLISH/50_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/FRENCH/0_Text.json assets/ext/FRENCH/1_Text.json assets/ext/FRENCH/2_Text.json assets/ext/FRENCH/3_Text.json assets/ext/FRENCH/4_Text.json assets/ext/FRENCH/5_Text.json assets/ext/FRENCH/6_Text.json assets/ext/FRENCH/7_Text.json assets/ext/FRENCH/8_Text.json assets/ext/FRENCH/9_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/FRENCH/10_Text.json assets/ext/FRENCH/11_Text.json assets/ext/FRENCH/12_Text.json assets/ext/FRENCH/13_Text.json assets/ext/FRENCH/14_Text.json assets/ext/FRENCH/15_Text.json assets/ext/FRENCH/16_Text.json assets/ext/FRENCH/17_Text.json assets/ext/FRENCH/18_Text.json assets/ext/FRENCH/19_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/FRENCH/20_Text.json assets/ext/FRENCH/21_Text.json assets/ext/FRENCH/22_Text.json assets/ext/FRENCH/23_Text.json assets/ext/FRENCH/24_Text.json assets/ext/FRENCH/25_Text.json assets/ext/FRENCH/26_Text.json assets/ext/FRENCH/27_Text.json assets/ext/FRENCH/28_Text.json assets/ext/FRENCH/29_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/FRENCH/30_Text.json assets/ext/FRENCH/31_Text.json assets/ext/FRENCH/32_Text.json assets/ext/FRENCH/33_Text.json assets/ext/FRENCH/34_Text.json assets/ext/FRENCH/35_Text.json assets/ext/FRENCH/36_Text.json assets/ext/FRENCH/37_Text.json assets/ext/FRENCH/38_Text.json assets/ext/FRENCH/39_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/FRENCH/40_Text.json assets/ext/FRENCH/41_Text.json assets/ext/FRENCH/42_Text.json assets/ext/FRENCH/43_Text.json assets/ext/FRENCH/44_Text.json assets/ext/FRENCH/45_Text.json assets/ext/FRENCH/46_Text.json assets/ext/FRENCH/47_Text.json assets/ext/FRENCH/48_Text.json assets/ext/FRENCH/49_Text.json assets/ext/FRENCH/50_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/GERMAN/0_Text.json assets/ext/GERMAN/1_Text.json assets/ext/GERMAN/2_Text.json assets/ext/GERMAN/3_Text.json assets/ext/GERMAN/4_Text.json assets/ext/GERMAN/5_Text.json assets/ext/GERMAN/6_Text.json assets/ext/GERMAN/7_Text.json assets/ext/GERMAN/8_Text.json assets/ext/GERMAN/9_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/GERMAN/10_Text.json assets/ext/GERMAN/11_Text.json assets/ext/GERMAN/12_Text.json assets/ext/GERMAN/13_Text.json assets/ext/GERMAN/14_Text.json assets/ext/GERMAN/15_Text.json assets/ext/GERMAN/16_Text.json assets/ext/GERMAN/17_Text.json assets/ext/GERMAN/18_Text.json assets/ext/GERMAN/19_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/GERMAN/20_Text.json assets/ext/GERMAN/21_Text.json assets/ext/GERMAN/22_Text.json assets/ext/GERMAN/23_Text.json assets/ext/GERMAN/24_Text.json assets/ext/GERMAN/25_Text.json assets/ext/GERMAN/26_Text.json assets/ext/GERMAN/27_Text.json assets/ext/GERMAN/28_Text.json assets/ext/GERMAN/29_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/GERMAN/30_Text.json assets/ext/GERMAN/31_Text.json assets/ext/GERMAN/32_Text.json assets/ext/GERMAN/33_Text.json assets/ext/GERMAN/34_Text.json assets/ext/GERMAN/35_Text.json assets/ext/GERMAN/36_Text.json assets/ext/GERMAN/37_Text.json assets/ext/GERMAN/38_Text.json assets/ext/GERMAN/39_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/GERMAN/40_Text.json assets/ext/GERMAN/41_Text.json assets/ext/GERMAN/42_Text.json assets/ext/GERMAN/43_Text.json assets/ext/GERMAN/44_Text.json assets/ext/GERMAN/45_Text.json assets/ext/GERMAN/46_Text.json assets/ext/GERMAN/47_Text.json assets/ext/GERMAN/48_Text.json assets/ext/GERMAN/49_Text.json assets/ext/GERMAN/50_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/ITALIAN/0_Text.json assets/ext/ITALIAN/1_Text.json assets/ext/ITALIAN/2_Text.json assets/ext/ITALIAN/3_Text.json assets/ext/ITALIAN/4_Text.json assets/ext/ITALIAN/5_Text.json assets/ext/ITALIAN/6_Text.json assets/ext/ITALIAN/7_Text.json assets/ext/ITALIAN/8_Text.json assets/ext/ITALIAN/9_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/ITALIAN/10_Text.json assets/ext/ITALIAN/11_Text.json assets/ext/ITALIAN/12_Text.json assets/ext/ITALIAN/13_Text.json assets/ext/ITALIAN/14_Text.json assets/ext/ITALIAN/15_Text.json assets/ext/ITALIAN/16_Text.json assets/ext/ITALIAN/17_Text.json assets/ext/ITALIAN/18_Text.json assets/ext/ITALIAN/19_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/ITALIAN/20_Text.json assets/ext/ITALIAN/21_Text.json assets/ext/ITALIAN/22_Text.json assets/ext/ITALIAN/23_Text.json assets/ext/ITALIAN/24_Text.json assets/ext/ITALIAN/25_Text.json assets/ext/ITALIAN/26_Text.json assets/ext/ITALIAN/27_Text.json assets/ext/ITALIAN/28_Text.json assets/ext/ITALIAN/29_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/ITALIAN/30_Text.json assets/ext/ITALIAN/31_Text.json assets/ext/ITALIAN/32_Text.json assets/ext/ITALIAN/33_Text.json assets/ext/ITALIAN/34_Text.json assets/ext/ITALIAN/35_Text.json assets/ext/ITALIAN/36_Text.json assets/ext/ITALIAN/37_Text.json assets/ext/ITALIAN/38_Text.json assets/ext/ITALIAN/39_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/ITALIAN/40_Text.json assets/ext/ITALIAN/41_Text.json assets/ext/ITALIAN/42_Text.json assets/ext/ITALIAN/43_Text.json assets/ext/ITALIAN/44_Text.json assets/ext/ITALIAN/45_Text.json assets/ext/ITALIAN/46_Text.json assets/ext/ITALIAN/47_Text.json assets/ext/ITALIAN/48_Text.json assets/ext/ITALIAN/49_Text.json assets/ext/ITALIAN/50_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/PORTUGUESE/0_Text.json assets/ext/PORTUGUESE/1_Text.json assets/ext/PORTUGUESE/2_Text.json assets/ext/PORTUGUESE/3_Text.json assets/ext/PORTUGUESE/4_Text.json assets/ext/PORTUGUESE/5_Text.json assets/ext/PORTUGUESE/6_Text.json assets/ext/PORTUGUESE/7_Text.json assets/ext/PORTUGUESE/8_Text.json assets/ext/PORTUGUESE/9_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/PORTUGUESE/10_Text.json assets/ext/PORTUGUESE/11_Text.json assets/ext/PORTUGUESE/12_Text.json assets/ext/PORTUGUESE/13_Text.json assets/ext/PORTUGUESE/14_Text.json assets/ext/PORTUGUESE/15_Text.json assets/ext/PORTUGUESE/16_Text.json assets/ext/PORTUGUESE/17_Text.json assets/ext/PORTUGUESE/18_Text.json assets/ext/PORTUGUESE/19_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/PORTUGUESE/20_Text.json assets/ext/PORTUGUESE/21_Text.json assets/ext/PORTUGUESE/22_Text.json assets/ext/PORTUGUESE/23_Text.json assets/ext/PORTUGUESE/24_Text.json assets/ext/PORTUGUESE/25_Text.json assets/ext/PORTUGUESE/26_Text.json assets/ext/PORTUGUESE/27_Text.json assets/ext/PORTUGUESE/28_Text.json assets/ext/PORTUGUESE/29_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/PORTUGUESE/30_Text.json assets/ext/PORTUGUESE/31_Text.json assets/ext/PORTUGUESE/32_Text.json assets/ext/PORTUGUESE/33_Text.json assets/ext/PORTUGUESE/34_Text.json assets/ext/PORTUGUESE/35_Text.json assets/ext/PORTUGUESE/36_Text.json assets/ext/PORTUGUESE/37_Text.json assets/ext/PORTUGUESE/38_Text.json assets/ext/PORTUGUESE/39_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/PORTUGUESE/40_Text.json assets/ext/PORTUGUESE/41_Text.json assets/ext/PORTUGUESE/42_Text.json assets/ext/PORTUGUESE/43_Text.json assets/ext/PORTUGUESE/44_Text.json assets/ext/PORTUGUESE/45_Text.json assets/ext/PORTUGUESE/46_Text.json assets/ext/PORTUGUESE/47_Text.json assets/ext/PORTUGUESE/48_Text.json assets/ext/PORTUGUESE/49_Text.json assets/ext/PORTUGUESE/50_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/SPANISH/0_Text.json assets/ext/SPANISH/1_Text.json assets/ext/SPANISH/2_Text.json assets/ext/SPANISH/3_Text.json assets/ext/SPANISH/4_Text.json assets/ext/SPANISH/5_Text.json assets/ext/SPANISH/6_Text.json assets/ext/SPANISH/7_Text.json assets/ext/SPANISH/8_Text.json assets/ext/SPANISH/9_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/SPANISH/10_Text.json assets/ext/SPANISH/11_Text.json assets/ext/SPANISH/12_Text.json assets/ext/SPANISH/13_Text.json assets/ext/SPANISH/14_Text.json assets/ext/SPANISH/15_Text.json assets/ext/SPANISH/16_Text.json assets/ext/SPANISH/17_Text.json assets/ext/SPANISH/18_Text.json assets/ext/SPANISH/19_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/SPANISH/20_Text.json assets/ext/SPANISH/21_Text.json assets/ext/SPANISH/22_Text.json assets/ext/SPANISH/23_Text.json assets/ext/SPANISH/24_Text.json assets/ext/SPANISH/25_Text.json assets/ext/SPANISH/26_Text.json assets/ext/SPANISH/27_Text.json assets/ext/SPANISH/28_Text.json assets/ext/SPANISH/29_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/SPANISH/30_Text.json assets/ext/SPANISH/31_Text.json assets/ext/SPANISH/32_Text.json assets/ext/SPANISH/33_Text.json assets/ext/SPANISH/34_Text.json assets/ext/SPANISH/35_Text.json assets/ext/SPANISH/36_Text.json assets/ext/SPANISH/37_Text.json assets/ext/SPANISH/38_Text.json assets/ext/SPANISH/39_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/ext/SPANISH/40_Text.json assets/ext/SPANISH/41_Text.json assets/ext/SPANISH/42_Text.json assets/ext/SPANISH/43_Text.json assets/ext/SPANISH/44_Text.json assets/ext/SPANISH/45_Text.json assets/ext/SPANISH/46_Text.json assets/ext/SPANISH/47_Text.json assets/ext/SPANISH/48_Text.json assets/ext/SPANISH/49_Text.json assets/ext/SPANISH/50_Text.json
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/Textures/texturegroup00_library_0.yytex assets/Textures/texturegroup00_shared_0.yytex
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/Textures/texturegroup01_0.yytex assets/Textures/texturegroup02_0.yytex assets/Textures/texturegroup03_0.yytex assets/Textures/texturegroup04_0.yytex assets/Textures/texturegroup05_0.yytex assets/Textures/texturegroup06_0.yytex
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/Textures/texturegroup07_0.yytex assets/Textures/texturegroup07_1.yytex assets/Textures/texturegroup07_2.yytex assets/Textures/texturegroup07_3.yytex assets/Textures/texturegroup07_4.yytex
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/Textures/texturegroup07_5.yytex assets/Textures/texturegroup07_6.yytex assets/Textures/texturegroup07_7.yytex assets/Textures/texturegroup07_8.yytex assets/Textures/texturegroup07_9.yytex
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/Textures/texturegroup07_10.yytex assets/Textures/texturegroup07_11.yytex assets/Textures/texturegroup07_12.yytex assets/Textures/texturegroup07_13.yytex assets/Textures/texturegroup07_14.yytex assets/Textures/texturegroup07_15.yytex
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/Textures/texturegroup08_0.yytex assets/Textures/texturegroup09_0.yytex assets/Textures/texturegroup09_1.yytex assets/Textures/texturegroup10_0.yytex assets/Textures/texturegroup11_0.yytex assets/Textures/texturegroup12_0.yytex assets/Textures/texturegroup12_1.yytex
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/Textures/texturegroup13_0.yytex assets/Textures/texturegroup14_0.yytex assets/Textures/texturegroup15_0.yytex assets/Textures/texturegroup16_0.yytex assets/Textures/texturegroup17_0.yytex assets/Textures/texturegroup18_0.yytex assets/Textures/texturegroup19_0.yytex
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/Textures/texturegroup20_0.yytex assets/Textures/texturegroup21_0.yytex assets/Textures/texturegroup22_0.yytex assets/Textures/texturegroup23_0.yytex assets/Textures/texturegroup24_0.yytex assets/Textures/texturegroup25_0.yytex
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/Textures/texturegroup26_0.yytex assets/Textures/texturegroup27_0.yytex assets/Textures/texturegroup28_0.yytex assets/Textures/texturegroup29_0.yytex assets/Textures/texturegroup30_0.yytex assets/Textures/texturegroup31_0.yytex
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/Textures/texturegroup32_0.yytex assets/Textures/texturegroup32_1.yytex assets/Textures/texturegroup32_2.yytex assets/Textures/texturegroup32_3.yytex assets/Textures/texturegroup32_4.yytex assets/Textures/texturegroup32_5.yytex
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/Textures/texturegroup32_6.yytex assets/Textures/texturegroup32_7.yytex assets/Textures/texturegroup32_8.yytex assets/Textures/texturegroup32_9.yytex assets/Textures/texturegroup32_10.yytex assets/Textures/texturegroup32_11.yytex
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/Textures/texturegroup32_12.yytex assets/Textures/texturegroup32_13.yytex assets/Textures/texturegroup32_14.yytex assets/Textures/texturegroup32_15.yytex assets/Textures/texturegroup32_16.yytex assets/Textures/texturegroup32_17.yytex assets/Textures/texturegroup32_18.yytex
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/Textures/texturegroup32_19.yytex assets/Textures/texturegroup32_20.yytex assets/Textures/texturegroup32_21.yytex assets/Textures/texturegroup32_22.yytex assets/Textures/texturegroup32_23.yytex assets/Textures/texturegroup32_24.yytex
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/Textures/texturegroup33_0.yytex assets/Textures/texturegroup33_1.yytex assets/Textures/texturegroup34_0.yytex assets/Textures/texturegroup35_0.yytex assets/Textures/texturegroup35_1.yytex assets/Textures/texturegroup35_2.yytex
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/Textures/texturegroup35_3.yytex assets/Textures/texturegroup35_4.yytex assets/Textures/texturegroup35_5.yytex assets/Textures/texturegroup36_0.yytex assets/Textures/texturegroup37_0.yytex assets/Textures/texturegroup38_0.yytex
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/Textures/texturegroup39_0.yytex assets/Textures/texturegroup39_1.yytex assets/Textures/texturegroup39_2.yytex assets/Textures/texturegroup39_3.yytex assets/Textures/texturegroup40_0.yytex assets/Textures/texturegroup41_0.yytex
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/Textures/texturegroup41_1.yytex assets/Textures/texturegroup41_2.yytex assets/Textures/texturegroup41_3.yytex assets/Textures/texturegroup41_4.yytex assets/Textures/texturegroup41_5.yytex assets/Textures/texturegroup41_6.yytex
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/Textures/texturegroup41_7.yytex assets/Textures/texturegroup42_0.yytex assets/Textures/texturegroup43_0.yytex assets/Textures/texturegroup44_0.yytex assets/Textures/texturegroup45_0.yytex assets/Textures/texturegroup45_1.yytex
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/Textures/texturegroup46_0.yytex assets/Textures/texturegroup47_0.yytex assets/Textures/texturegroup48_0.yytex assets/Textures/texturegroup49_0.yytex assets/Textures/texturegroup50_0.yytex assets/Textures/texturegroup51_0.yytex
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/options.ini
-./bin/aapt-linux add -f -v UFO50Wrapper.apk assets/game.droid
+add_assets
+
+# Store externally loaded files without compression. GameMaker's Android
+# buffer_load path uses asset file descriptors and can fail on compressed APK
+# entries, especially for the localization JSON files loaded at startup.
+python3 - <<'PY'
+from pathlib import Path
+import os
+import zipfile
+
+apk = Path('UFO50Wrapper.apk')
+tmp = apk.with_suffix('.apk.tmp')
+store_prefixes = ('assets/ext/', 'assets/fonts/')
+with zipfile.ZipFile(apk, 'r') as zin, zipfile.ZipFile(tmp, 'w') as zout:
+    for info in zin.infolist():
+        data = zin.read(info.filename)
+        zi = zipfile.ZipInfo(info.filename, info.date_time)
+        zi.comment = info.comment
+        zi.extra = info.extra
+        zi.external_attr = info.external_attr
+        zi.compress_type = zipfile.ZIP_STORED if info.filename.startswith(store_prefixes) else info.compress_type
+        zout.writestr(zi, data)
+os.replace(tmp, apk)
+PY
 
 # Zipalign and sign APK
 echo "Building APK..."
-./bin/zipalign -p -f -v 4 UFO50Wrapper.apk com.unofficial.ufo50.zipalign.apk
-./bin/java/bin/java -jar ./bin/apksigner.jar sign --key ./base/testkey.pk8 --cert ./base/testkey.x509.pem --out com.unofficial.ufo50.apk com.unofficial.ufo50.zipalign.apk
+"${ZIPALIGN}" -p -f -v 4 UFO50Wrapper.apk com.unofficial.ufo50.zipalign.apk
+"${JAVA}" -jar ./bin/apksigner.jar sign --key ./base/testkey.pk8 --cert ./base/testkey.x509.pem --out "${OUTPUT_APK}" com.unofficial.ufo50.zipalign.apk
 
 # Clean up
 echo "Cleaning up..."
@@ -128,6 +197,5 @@ rm -f ./com.unofficial.ufo50.apk.idsig
 rm -f ./UFO50Wrapper.apk
 rm -rf ./assets
 
-echo "Done! Have fun."
-read -n 1 -s -r -p "Press any key to continue..."
-echo
+echo "Done! Built ${OUTPUT_APK}. Have fun."
+if [ -t 0 ]; then read -n 1 -s -r -p "Press any key to continue..."; echo; fi

--- a/build_macos.sh
+++ b/build_macos.sh
@@ -1,31 +1,43 @@
 #!/bin/bash
+set -euo pipefail
 
-set -e
-
-if ! command -v wget 2>&1 >/dev/null; then
+if ! command -v wget >/dev/null 2>&1; then
     echo "ERROR: Missing prerequisite: wget"
     exit 1
 fi
 
-if ! command -v unzip 2>&1 >/dev/null; then
+if ! command -v unzip >/dev/null 2>&1; then
     echo "ERROR: Missing prerequisite: unzip"
     exit 1
 fi
 
-# Linux: https://corretto.aws/downloads/resources/21.0.2.13.1/amazon-corretto-21.0.2.13.1-linux-x64-jdk.zip
-# OSX: https://corretto.aws/downloads/resources/21.0.5.11.1/amazon-corretto-21.0.5.11.1-macosx-x64.tar.gz
+UFO50_SOURCE="${1:-${UFO50_SOURCE:-./ufo50}}"
+WRAPPER_APK="${UFO50_WRAPPER_APK:-./base/AndroidWrapper2024.1400.4.968_VM_debug_gamepad_hotplug.apk}"
+AAPT="./bin/aapt-osx"
+ZIPALIGN="./bin/zipalign-osx"
+JAVA="./bin/java/Contents/Home/bin/java"
+OUTPUT_APK="com.unofficial.ufo50.apk"
 
 # Make sure that we actually have game files first
-if [ ! -f ./ufo50/data.win ]; then
-	echo "Place your UFO 50 game files in the ufo50 folder first!"
-	read -n 1 -s -r -p "Press any key to continue..."
-	echo
-	exit 1
+if [ ! -f "${UFO50_SOURCE}/data.win" ]; then
+    echo "Place your UFO 50 game files in ${UFO50_SOURCE} first, pass the path as the first argument, or set UFO50_SOURCE."
+    if [ -t 0 ]; then read -n 1 -s -r -p "Press any key to continue..."; echo; fi
+    exit 1
+fi
+
+if [ ! -f "${UFO50_SOURCE}/options.ini" ]; then
+    echo "ERROR: Missing ${UFO50_SOURCE}/options.ini"
+    exit 1
+fi
+
+if [ ! -f "${WRAPPER_APK}" ]; then
+    echo "ERROR: Missing wrapper APK: ${WRAPPER_APK}"
+    exit 1
 fi
 
 # Permissions
-chmod +x ./bin/zipalign-osx
-chmod +x ./bin/aapt-osx
+chmod +x "${ZIPALIGN}"
+chmod +x "${AAPT}"
 
 # Clean up from any previous runs
 rm -f ./UFO50Wrapper.apk
@@ -33,100 +45,155 @@ rm -f ./com.unofficial.ufo50.zip
 rm -rf ./assets
 mkdir ./assets
 
-# Copy required assets
-echo "Preparing assets..."
-cp -r ./ufo50/ext ./assets/ext
-cp -r ./ufo50/Textures ./assets/Textures
-cp ./ufo50/*.dat ./assets/
-cp ./ufo50/options.ini ./assets/
-cp ./ufo50/data.win ./assets/game.droid
-cp ./base/AndroidWrapper2024.8.0.216_VM_debug.apk ./UFO50Wrapper.apk
+# Copy required assets. Keep this discovery-based so new UFO 50 releases work when
+# texture groups, audio groups, fonts, or localization files are added/removed.
+echo "Preparing assets from ${UFO50_SOURCE}..."
+[ ! -d "${UFO50_SOURCE}/ext" ] || cp -R "${UFO50_SOURCE}/ext" ./assets/ext
+[ ! -d "${UFO50_SOURCE}/Textures" ] || cp -R "${UFO50_SOURCE}/Textures" ./assets/Textures
+[ ! -d "${UFO50_SOURCE}/fonts" ] || cp -R "${UFO50_SOURCE}/fonts" ./assets/fonts
+for dat in "${UFO50_SOURCE}"/*.dat; do
+    [ -e "${dat}" ] || continue
+    cp "${dat}" ./assets/
+done
+cp "${UFO50_SOURCE}/options.ini" ./assets/
+cp "${UFO50_SOURCE}/data.win" ./assets/game.droid
+cp "${WRAPPER_APK}" ./UFO50Wrapper.apk
+
+# Android APK assets are case-sensitive, while the GameMaker runtime lowercases
+# datafile paths (for example ext/english/0_text.json and textures/*.yytex).
+# Normalize staged sidecar assets to lowercase paths so they can be found.
+python3 - <<'PY'
+from pathlib import Path
+import shutil
+
+root = Path('./assets')
+tmp = Path('./assets.lowercase')
+if tmp.exists():
+    shutil.rmtree(tmp)
+tmp.mkdir()
+
+for path in root.rglob('*'):
+    rel = path.relative_to(root)
+    lower_rel = Path(*[part.lower() for part in rel.parts])
+    dest = tmp / lower_rel
+    if path.is_dir():
+        dest.mkdir(parents=True, exist_ok=True)
+    else:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, dest)
+
+shutil.rmtree(root)
+tmp.rename(root)
+PY
+
+# Some current PC builds have trailing bytes after the GameMaker FORM chunk.
+# The Android runner rejects those with "unexpected size", so trim game.droid
+# to the FORM header size when needed.
+python3 - <<'PY'
+from pathlib import Path
+path = Path('./assets/game.droid')
+with path.open('rb') as fh:
+    header = fh.read(8)
+if len(header) != 8 or header[:4] != b'FORM':
+    raise SystemExit('ERROR: assets/game.droid is not a GameMaker FORM file')
+expected = int.from_bytes(header[4:8], 'little') + 8
+actual = path.stat().st_size
+if actual > expected:
+    print(f'Trimming game.droid from {actual} to FORM size {expected} bytes')
+    with path.open('r+b') as fh:
+        fh.truncate(expected)
+elif actual < expected:
+    raise SystemExit(f'ERROR: game.droid is smaller than FORM header size ({actual} < {expected})')
+PY
+
+# The PC data has a Steamworks extension, but its Android class name is blank.
+# GameMaker then looks for com.unofficial.ufo50. and never calls our Android
+# stub. Patch the EXTN metadata so Steamworks calls are routed to
+# com.unofficial.ufo50.Steamworks.
+UTMT_CLI="${UTMT_CLI:-./bin/utmt/UndertaleModCli}"
+if [ ! -x "${UTMT_CLI}" ]; then
+    echo "Downloading UndertaleModCli..."
+    rm -rf ./bin/utmt ./utmt.zip
+    mkdir -p ./bin/utmt
+    wget https://github.com/UnderminersTeam/UndertaleModTool/releases/download/0.9.1.0/UTMT_CLI_v0.9.1.0-macOS.zip -O ./utmt.zip
+    unzip -q ./utmt.zip -d ./bin/utmt
+    rm -f ./utmt.zip
+    chmod +x "${UTMT_CLI}"
+fi
+
+echo "Patching Steamworks extension metadata for Android..."
+"${UTMT_CLI}" load ./assets/game.droid -s ./scripts/patch_ufo50_android.csx -o ./assets/game.droid.patched
+mv ./assets/game.droid.patched ./assets/game.droid
 
 # Download Java, if needed
-if [ ! -f ./bin/java/Contents/Home/bin/java ]; then
-	ARCH="x64"
-	if [[ $(uname -m) == 'arm64' ]]; then
-		ARCH="aarch64"
-	fi
+if [ ! -f "${JAVA}" ]; then
+    ARCH="x64"
+    if [[ $(uname -m) == 'arm64' ]]; then
+        ARCH="aarch64"
+    fi
 
-	rm -rf ./bin/java
-	echo "Downloading java..."
-	wget https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-macosx-${ARCH}.tar.gz -O ./jdk.tar.gz
-	echo "Extracting java..."
-	tar -zxvf ./jdk.tar.gz
-	mv ./amazon-corretto-21.jdk ./bin/java
-	rm -f ./jdk.tar.gz
+    rm -rf ./bin/java
+    echo "Downloading java..."
+    wget https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-macosx-${ARCH}.tar.gz -O ./jdk.tar.gz
+    echo "Extracting java..."
+    tar -zxvf ./jdk.tar.gz
+    mv ./amazon-corretto-21.jdk ./bin/java
+    rm -f ./jdk.tar.gz
 fi
 
 # Clean wrapper apk
+# The base wrapper contains placeholder game.droid/options.ini; replace them.
 echo "Preparing wrapper..."
-./bin/aapt-osx remove -f -v UFO50Wrapper.apk assets/options.ini
-./bin/aapt-osx remove -f -v UFO50Wrapper.apk assets/game.droid
+"${AAPT}" remove -f -v UFO50Wrapper.apk assets/options.ini || true
+"${AAPT}" remove -f -v UFO50Wrapper.apk assets/game.droid || true
+
+add_assets() {
+    local batch=()
+    local file
+    while IFS= read -r file; do
+        batch+=("${file}")
+        if [ "${#batch[@]}" -ge 80 ]; then
+            "${AAPT}" add -f -v UFO50Wrapper.apk "${batch[@]}"
+            batch=()
+        fi
+    done < <(find assets -type f | LC_ALL=C sort)
+
+    if [ "${#batch[@]}" -gt 0 ]; then
+        "${AAPT}" add -f -v UFO50Wrapper.apk "${batch[@]}"
+    fi
+}
 
 # Add game assets to base wrapper APK
 echo "Building wrapper..."
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/audiogroup1.dat assets/audiogroup2.dat assets/audiogroup3.dat assets/audiogroup4.dat assets/audiogroup5.dat assets/audiogroup6.dat assets/audiogroup7.dat assets/audiogroup8.dat assets/audiogroup9.dat
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/audiogroup10.dat assets/audiogroup11.dat assets/audiogroup12.dat assets/audiogroup13.dat assets/audiogroup14.dat assets/audiogroup15.dat assets/audiogroup16.dat assets/audiogroup17.dat assets/audiogroup18.dat assets/audiogroup19.dat
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/audiogroup20.dat assets/audiogroup21.dat assets/audiogroup22.dat assets/audiogroup23.dat assets/audiogroup24.dat assets/audiogroup25.dat assets/audiogroup26.dat assets/audiogroup27.dat assets/audiogroup28.dat assets/audiogroup29.dat
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/audiogroup30.dat assets/audiogroup31.dat assets/audiogroup32.dat assets/audiogroup33.dat assets/audiogroup34.dat assets/audiogroup35.dat assets/audiogroup36.dat assets/audiogroup37.dat assets/audiogroup38.dat assets/audiogroup39.dat
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/audiogroup40.dat assets/audiogroup41.dat assets/audiogroup43.dat assets/audiogroup44.dat assets/audiogroup45.dat assets/audiogroup46.dat assets/audiogroup47.dat assets/audiogroup48.dat assets/audiogroup49.dat
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/audiogroup50.dat assets/audiogroup51.dat assets/audiogroup52.dat assets/audiogroup53.dat
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/ENGLISH/0_Text.json assets/ext/ENGLISH/1_Text.json assets/ext/ENGLISH/2_Text.json assets/ext/ENGLISH/3_Text.json assets/ext/ENGLISH/4_Text.json assets/ext/ENGLISH/5_Text.json assets/ext/ENGLISH/6_Text.json assets/ext/ENGLISH/7_Text.json assets/ext/ENGLISH/8_Text.json assets/ext/ENGLISH/9_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/ENGLISH/10_Text.json assets/ext/ENGLISH/11_Text.json assets/ext/ENGLISH/12_Text.json assets/ext/ENGLISH/13_Text.json assets/ext/ENGLISH/14_Text.json assets/ext/ENGLISH/15_Text.json assets/ext/ENGLISH/16_Text.json assets/ext/ENGLISH/17_Text.json assets/ext/ENGLISH/18_Text.json assets/ext/ENGLISH/19_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/ENGLISH/20_Text.json assets/ext/ENGLISH/21_Text.json assets/ext/ENGLISH/22_Text.json assets/ext/ENGLISH/23_Text.json assets/ext/ENGLISH/24_Text.json assets/ext/ENGLISH/25_Text.json assets/ext/ENGLISH/26_Text.json assets/ext/ENGLISH/27_Text.json assets/ext/ENGLISH/28_Text.json assets/ext/ENGLISH/29_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/ENGLISH/30_Text.json assets/ext/ENGLISH/31_Text.json assets/ext/ENGLISH/32_Text.json assets/ext/ENGLISH/33_Text.json assets/ext/ENGLISH/34_Text.json assets/ext/ENGLISH/35_Text.json assets/ext/ENGLISH/36_Text.json assets/ext/ENGLISH/37_Text.json assets/ext/ENGLISH/38_Text.json assets/ext/ENGLISH/39_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/ENGLISH/40_Text.json assets/ext/ENGLISH/41_Text.json assets/ext/ENGLISH/42_Text.json assets/ext/ENGLISH/43_Text.json assets/ext/ENGLISH/44_Text.json assets/ext/ENGLISH/45_Text.json assets/ext/ENGLISH/46_Text.json assets/ext/ENGLISH/47_Text.json assets/ext/ENGLISH/48_Text.json assets/ext/ENGLISH/49_Text.json assets/ext/ENGLISH/50_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/FRENCH/0_Text.json assets/ext/FRENCH/1_Text.json assets/ext/FRENCH/2_Text.json assets/ext/FRENCH/3_Text.json assets/ext/FRENCH/4_Text.json assets/ext/FRENCH/5_Text.json assets/ext/FRENCH/6_Text.json assets/ext/FRENCH/7_Text.json assets/ext/FRENCH/8_Text.json assets/ext/FRENCH/9_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/FRENCH/10_Text.json assets/ext/FRENCH/11_Text.json assets/ext/FRENCH/12_Text.json assets/ext/FRENCH/13_Text.json assets/ext/FRENCH/14_Text.json assets/ext/FRENCH/15_Text.json assets/ext/FRENCH/16_Text.json assets/ext/FRENCH/17_Text.json assets/ext/FRENCH/18_Text.json assets/ext/FRENCH/19_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/FRENCH/20_Text.json assets/ext/FRENCH/21_Text.json assets/ext/FRENCH/22_Text.json assets/ext/FRENCH/23_Text.json assets/ext/FRENCH/24_Text.json assets/ext/FRENCH/25_Text.json assets/ext/FRENCH/26_Text.json assets/ext/FRENCH/27_Text.json assets/ext/FRENCH/28_Text.json assets/ext/FRENCH/29_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/FRENCH/30_Text.json assets/ext/FRENCH/31_Text.json assets/ext/FRENCH/32_Text.json assets/ext/FRENCH/33_Text.json assets/ext/FRENCH/34_Text.json assets/ext/FRENCH/35_Text.json assets/ext/FRENCH/36_Text.json assets/ext/FRENCH/37_Text.json assets/ext/FRENCH/38_Text.json assets/ext/FRENCH/39_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/FRENCH/40_Text.json assets/ext/FRENCH/41_Text.json assets/ext/FRENCH/42_Text.json assets/ext/FRENCH/43_Text.json assets/ext/FRENCH/44_Text.json assets/ext/FRENCH/45_Text.json assets/ext/FRENCH/46_Text.json assets/ext/FRENCH/47_Text.json assets/ext/FRENCH/48_Text.json assets/ext/FRENCH/49_Text.json assets/ext/FRENCH/50_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/GERMAN/0_Text.json assets/ext/GERMAN/1_Text.json assets/ext/GERMAN/2_Text.json assets/ext/GERMAN/3_Text.json assets/ext/GERMAN/4_Text.json assets/ext/GERMAN/5_Text.json assets/ext/GERMAN/6_Text.json assets/ext/GERMAN/7_Text.json assets/ext/GERMAN/8_Text.json assets/ext/GERMAN/9_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/GERMAN/10_Text.json assets/ext/GERMAN/11_Text.json assets/ext/GERMAN/12_Text.json assets/ext/GERMAN/13_Text.json assets/ext/GERMAN/14_Text.json assets/ext/GERMAN/15_Text.json assets/ext/GERMAN/16_Text.json assets/ext/GERMAN/17_Text.json assets/ext/GERMAN/18_Text.json assets/ext/GERMAN/19_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/GERMAN/20_Text.json assets/ext/GERMAN/21_Text.json assets/ext/GERMAN/22_Text.json assets/ext/GERMAN/23_Text.json assets/ext/GERMAN/24_Text.json assets/ext/GERMAN/25_Text.json assets/ext/GERMAN/26_Text.json assets/ext/GERMAN/27_Text.json assets/ext/GERMAN/28_Text.json assets/ext/GERMAN/29_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/GERMAN/30_Text.json assets/ext/GERMAN/31_Text.json assets/ext/GERMAN/32_Text.json assets/ext/GERMAN/33_Text.json assets/ext/GERMAN/34_Text.json assets/ext/GERMAN/35_Text.json assets/ext/GERMAN/36_Text.json assets/ext/GERMAN/37_Text.json assets/ext/GERMAN/38_Text.json assets/ext/GERMAN/39_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/GERMAN/40_Text.json assets/ext/GERMAN/41_Text.json assets/ext/GERMAN/42_Text.json assets/ext/GERMAN/43_Text.json assets/ext/GERMAN/44_Text.json assets/ext/GERMAN/45_Text.json assets/ext/GERMAN/46_Text.json assets/ext/GERMAN/47_Text.json assets/ext/GERMAN/48_Text.json assets/ext/GERMAN/49_Text.json assets/ext/GERMAN/50_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/ITALIAN/0_Text.json assets/ext/ITALIAN/1_Text.json assets/ext/ITALIAN/2_Text.json assets/ext/ITALIAN/3_Text.json assets/ext/ITALIAN/4_Text.json assets/ext/ITALIAN/5_Text.json assets/ext/ITALIAN/6_Text.json assets/ext/ITALIAN/7_Text.json assets/ext/ITALIAN/8_Text.json assets/ext/ITALIAN/9_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/ITALIAN/10_Text.json assets/ext/ITALIAN/11_Text.json assets/ext/ITALIAN/12_Text.json assets/ext/ITALIAN/13_Text.json assets/ext/ITALIAN/14_Text.json assets/ext/ITALIAN/15_Text.json assets/ext/ITALIAN/16_Text.json assets/ext/ITALIAN/17_Text.json assets/ext/ITALIAN/18_Text.json assets/ext/ITALIAN/19_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/ITALIAN/20_Text.json assets/ext/ITALIAN/21_Text.json assets/ext/ITALIAN/22_Text.json assets/ext/ITALIAN/23_Text.json assets/ext/ITALIAN/24_Text.json assets/ext/ITALIAN/25_Text.json assets/ext/ITALIAN/26_Text.json assets/ext/ITALIAN/27_Text.json assets/ext/ITALIAN/28_Text.json assets/ext/ITALIAN/29_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/ITALIAN/30_Text.json assets/ext/ITALIAN/31_Text.json assets/ext/ITALIAN/32_Text.json assets/ext/ITALIAN/33_Text.json assets/ext/ITALIAN/34_Text.json assets/ext/ITALIAN/35_Text.json assets/ext/ITALIAN/36_Text.json assets/ext/ITALIAN/37_Text.json assets/ext/ITALIAN/38_Text.json assets/ext/ITALIAN/39_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/ITALIAN/40_Text.json assets/ext/ITALIAN/41_Text.json assets/ext/ITALIAN/42_Text.json assets/ext/ITALIAN/43_Text.json assets/ext/ITALIAN/44_Text.json assets/ext/ITALIAN/45_Text.json assets/ext/ITALIAN/46_Text.json assets/ext/ITALIAN/47_Text.json assets/ext/ITALIAN/48_Text.json assets/ext/ITALIAN/49_Text.json assets/ext/ITALIAN/50_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/PORTUGUESE/0_Text.json assets/ext/PORTUGUESE/1_Text.json assets/ext/PORTUGUESE/2_Text.json assets/ext/PORTUGUESE/3_Text.json assets/ext/PORTUGUESE/4_Text.json assets/ext/PORTUGUESE/5_Text.json assets/ext/PORTUGUESE/6_Text.json assets/ext/PORTUGUESE/7_Text.json assets/ext/PORTUGUESE/8_Text.json assets/ext/PORTUGUESE/9_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/PORTUGUESE/10_Text.json assets/ext/PORTUGUESE/11_Text.json assets/ext/PORTUGUESE/12_Text.json assets/ext/PORTUGUESE/13_Text.json assets/ext/PORTUGUESE/14_Text.json assets/ext/PORTUGUESE/15_Text.json assets/ext/PORTUGUESE/16_Text.json assets/ext/PORTUGUESE/17_Text.json assets/ext/PORTUGUESE/18_Text.json assets/ext/PORTUGUESE/19_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/PORTUGUESE/20_Text.json assets/ext/PORTUGUESE/21_Text.json assets/ext/PORTUGUESE/22_Text.json assets/ext/PORTUGUESE/23_Text.json assets/ext/PORTUGUESE/24_Text.json assets/ext/PORTUGUESE/25_Text.json assets/ext/PORTUGUESE/26_Text.json assets/ext/PORTUGUESE/27_Text.json assets/ext/PORTUGUESE/28_Text.json assets/ext/PORTUGUESE/29_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/PORTUGUESE/30_Text.json assets/ext/PORTUGUESE/31_Text.json assets/ext/PORTUGUESE/32_Text.json assets/ext/PORTUGUESE/33_Text.json assets/ext/PORTUGUESE/34_Text.json assets/ext/PORTUGUESE/35_Text.json assets/ext/PORTUGUESE/36_Text.json assets/ext/PORTUGUESE/37_Text.json assets/ext/PORTUGUESE/38_Text.json assets/ext/PORTUGUESE/39_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/PORTUGUESE/40_Text.json assets/ext/PORTUGUESE/41_Text.json assets/ext/PORTUGUESE/42_Text.json assets/ext/PORTUGUESE/43_Text.json assets/ext/PORTUGUESE/44_Text.json assets/ext/PORTUGUESE/45_Text.json assets/ext/PORTUGUESE/46_Text.json assets/ext/PORTUGUESE/47_Text.json assets/ext/PORTUGUESE/48_Text.json assets/ext/PORTUGUESE/49_Text.json assets/ext/PORTUGUESE/50_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/SPANISH/0_Text.json assets/ext/SPANISH/1_Text.json assets/ext/SPANISH/2_Text.json assets/ext/SPANISH/3_Text.json assets/ext/SPANISH/4_Text.json assets/ext/SPANISH/5_Text.json assets/ext/SPANISH/6_Text.json assets/ext/SPANISH/7_Text.json assets/ext/SPANISH/8_Text.json assets/ext/SPANISH/9_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/SPANISH/10_Text.json assets/ext/SPANISH/11_Text.json assets/ext/SPANISH/12_Text.json assets/ext/SPANISH/13_Text.json assets/ext/SPANISH/14_Text.json assets/ext/SPANISH/15_Text.json assets/ext/SPANISH/16_Text.json assets/ext/SPANISH/17_Text.json assets/ext/SPANISH/18_Text.json assets/ext/SPANISH/19_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/SPANISH/20_Text.json assets/ext/SPANISH/21_Text.json assets/ext/SPANISH/22_Text.json assets/ext/SPANISH/23_Text.json assets/ext/SPANISH/24_Text.json assets/ext/SPANISH/25_Text.json assets/ext/SPANISH/26_Text.json assets/ext/SPANISH/27_Text.json assets/ext/SPANISH/28_Text.json assets/ext/SPANISH/29_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/SPANISH/30_Text.json assets/ext/SPANISH/31_Text.json assets/ext/SPANISH/32_Text.json assets/ext/SPANISH/33_Text.json assets/ext/SPANISH/34_Text.json assets/ext/SPANISH/35_Text.json assets/ext/SPANISH/36_Text.json assets/ext/SPANISH/37_Text.json assets/ext/SPANISH/38_Text.json assets/ext/SPANISH/39_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/ext/SPANISH/40_Text.json assets/ext/SPANISH/41_Text.json assets/ext/SPANISH/42_Text.json assets/ext/SPANISH/43_Text.json assets/ext/SPANISH/44_Text.json assets/ext/SPANISH/45_Text.json assets/ext/SPANISH/46_Text.json assets/ext/SPANISH/47_Text.json assets/ext/SPANISH/48_Text.json assets/ext/SPANISH/49_Text.json assets/ext/SPANISH/50_Text.json
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/Textures/texturegroup00_library_0.yytex assets/Textures/texturegroup00_shared_0.yytex
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/Textures/texturegroup01_0.yytex assets/Textures/texturegroup02_0.yytex assets/Textures/texturegroup03_0.yytex assets/Textures/texturegroup04_0.yytex assets/Textures/texturegroup05_0.yytex assets/Textures/texturegroup06_0.yytex
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/Textures/texturegroup07_0.yytex assets/Textures/texturegroup07_1.yytex assets/Textures/texturegroup07_2.yytex assets/Textures/texturegroup07_3.yytex assets/Textures/texturegroup07_4.yytex
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/Textures/texturegroup07_5.yytex assets/Textures/texturegroup07_6.yytex assets/Textures/texturegroup07_7.yytex assets/Textures/texturegroup07_8.yytex assets/Textures/texturegroup07_9.yytex
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/Textures/texturegroup07_10.yytex assets/Textures/texturegroup07_11.yytex assets/Textures/texturegroup07_12.yytex assets/Textures/texturegroup07_13.yytex assets/Textures/texturegroup07_14.yytex assets/Textures/texturegroup07_15.yytex
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/Textures/texturegroup08_0.yytex assets/Textures/texturegroup09_0.yytex assets/Textures/texturegroup09_1.yytex assets/Textures/texturegroup10_0.yytex assets/Textures/texturegroup11_0.yytex assets/Textures/texturegroup12_0.yytex assets/Textures/texturegroup12_1.yytex
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/Textures/texturegroup13_0.yytex assets/Textures/texturegroup14_0.yytex assets/Textures/texturegroup15_0.yytex assets/Textures/texturegroup16_0.yytex assets/Textures/texturegroup17_0.yytex assets/Textures/texturegroup18_0.yytex assets/Textures/texturegroup19_0.yytex
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/Textures/texturegroup20_0.yytex assets/Textures/texturegroup21_0.yytex assets/Textures/texturegroup22_0.yytex assets/Textures/texturegroup23_0.yytex assets/Textures/texturegroup24_0.yytex assets/Textures/texturegroup25_0.yytex
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/Textures/texturegroup26_0.yytex assets/Textures/texturegroup27_0.yytex assets/Textures/texturegroup28_0.yytex assets/Textures/texturegroup29_0.yytex assets/Textures/texturegroup30_0.yytex assets/Textures/texturegroup31_0.yytex
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/Textures/texturegroup32_0.yytex assets/Textures/texturegroup32_1.yytex assets/Textures/texturegroup32_2.yytex assets/Textures/texturegroup32_3.yytex assets/Textures/texturegroup32_4.yytex assets/Textures/texturegroup32_5.yytex
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/Textures/texturegroup32_6.yytex assets/Textures/texturegroup32_7.yytex assets/Textures/texturegroup32_8.yytex assets/Textures/texturegroup32_9.yytex assets/Textures/texturegroup32_10.yytex assets/Textures/texturegroup32_11.yytex
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/Textures/texturegroup32_12.yytex assets/Textures/texturegroup32_13.yytex assets/Textures/texturegroup32_14.yytex assets/Textures/texturegroup32_15.yytex assets/Textures/texturegroup32_16.yytex assets/Textures/texturegroup32_17.yytex assets/Textures/texturegroup32_18.yytex
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/Textures/texturegroup32_19.yytex assets/Textures/texturegroup32_20.yytex assets/Textures/texturegroup32_21.yytex assets/Textures/texturegroup32_22.yytex assets/Textures/texturegroup32_23.yytex assets/Textures/texturegroup32_24.yytex
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/Textures/texturegroup33_0.yytex assets/Textures/texturegroup33_1.yytex assets/Textures/texturegroup34_0.yytex assets/Textures/texturegroup35_0.yytex assets/Textures/texturegroup35_1.yytex assets/Textures/texturegroup35_2.yytex
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/Textures/texturegroup35_3.yytex assets/Textures/texturegroup35_4.yytex assets/Textures/texturegroup35_5.yytex assets/Textures/texturegroup36_0.yytex assets/Textures/texturegroup37_0.yytex assets/Textures/texturegroup38_0.yytex
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/Textures/texturegroup39_0.yytex assets/Textures/texturegroup39_1.yytex assets/Textures/texturegroup39_2.yytex assets/Textures/texturegroup39_3.yytex assets/Textures/texturegroup40_0.yytex assets/Textures/texturegroup41_0.yytex
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/Textures/texturegroup41_1.yytex assets/Textures/texturegroup41_2.yytex assets/Textures/texturegroup41_3.yytex assets/Textures/texturegroup41_4.yytex assets/Textures/texturegroup41_5.yytex assets/Textures/texturegroup41_6.yytex
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/Textures/texturegroup41_7.yytex assets/Textures/texturegroup42_0.yytex assets/Textures/texturegroup43_0.yytex assets/Textures/texturegroup44_0.yytex assets/Textures/texturegroup45_0.yytex assets/Textures/texturegroup45_1.yytex
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/Textures/texturegroup46_0.yytex assets/Textures/texturegroup47_0.yytex assets/Textures/texturegroup48_0.yytex assets/Textures/texturegroup49_0.yytex assets/Textures/texturegroup50_0.yytex assets/Textures/texturegroup51_0.yytex
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/options.ini
-./bin/aapt-osx add -f -v UFO50Wrapper.apk assets/game.droid
+add_assets
+
+# Store externally loaded files without compression. GameMaker's Android
+# buffer_load path uses asset file descriptors and can fail on compressed APK
+# entries, especially for localization JSON files loaded at startup.
+python3 - <<'PY'
+from pathlib import Path
+import os
+import zipfile
+
+apk = Path('UFO50Wrapper.apk')
+tmp = apk.with_suffix('.apk.tmp')
+store_prefixes = ('assets/ext/', 'assets/fonts/')
+with zipfile.ZipFile(apk, 'r') as zin, zipfile.ZipFile(tmp, 'w') as zout:
+    for info in zin.infolist():
+        data = zin.read(info.filename)
+        zi = zipfile.ZipInfo(info.filename, info.date_time)
+        zi.comment = info.comment
+        zi.extra = info.extra
+        zi.external_attr = info.external_attr
+        zi.compress_type = zipfile.ZIP_STORED if info.filename.startswith(store_prefixes) else info.compress_type
+        zout.writestr(zi, data)
+os.replace(tmp, apk)
+PY
 
 # Zipalign and sign APK
 echo "Building APK..."
-./bin/zipalign-osx -p -f -v 4 UFO50Wrapper.apk com.unofficial.ufo50.zipalign.apk
-./bin/java/Contents/Home/bin/java -jar ./bin/apksigner.jar sign --key ./base/testkey.pk8 --cert ./base/testkey.x509.pem --out com.unofficial.ufo50.apk com.unofficial.ufo50.zipalign.apk
+"${ZIPALIGN}" -p -f -v 4 UFO50Wrapper.apk com.unofficial.ufo50.zipalign.apk
+"${JAVA}" -jar ./bin/apksigner.jar sign --key ./base/testkey.pk8 --cert ./base/testkey.x509.pem --out "${OUTPUT_APK}" com.unofficial.ufo50.zipalign.apk
 
 # Clean up
 echo "Cleaning up..."
@@ -135,6 +202,5 @@ rm -f ./com.unofficial.ufo50.apk.idsig
 rm -f ./UFO50Wrapper.apk
 rm -rf ./assets
 
-echo "Done! Have fun."
-read -n 1 -s -r -p "Press any key to continue..."
-echo
+echo "Done! Built ${OUTPUT_APK}. Have fun."
+if [ -t 0 ]; then read -n 1 -s -r -p "Press any key to continue..."; echo; fi

--- a/build_windows.bat
+++ b/build_windows.bat
@@ -75,8 +75,8 @@ move /y .\assets\game.droid.patched .\assets\game.droid
 REM Clean wrapper apk
 REM The base wrapper contains placeholder game.droid/options.ini; replace them.
 echo Preparing wrapper...
-.\bin\aapt remove -f -v UFO50Wrapper.apk assets/options.ini
-.\bin\aapt remove -f -v UFO50Wrapper.apk assets/game.droid
+.\bin\aapt.exe remove -f -v UFO50Wrapper.apk assets/options.ini
+.\bin\aapt.exe remove -f -v UFO50Wrapper.apk assets/game.droid
 
 : JAVA
 REM Download Java, if needed
@@ -106,7 +106,7 @@ for /r assets %%F in (*) do (
 	set "asset=%%F"
 	set "asset=!asset:%CD%\=!"
 	set "asset=!asset:\=/!"
-	.\bin\aapt add -f -v UFO50Wrapper.apk "!asset!"
+	.\bin\aapt.exe add -f -v UFO50Wrapper.apk "!asset!"
 	if errorlevel 1 exit /b !errorlevel!
 )
 

--- a/build_windows.bat
+++ b/build_windows.bat
@@ -1,29 +1,79 @@
 @echo off
+setlocal EnableExtensions EnableDelayedExpansion
+
+set "UFO50_SOURCE=%~1"
+if "%UFO50_SOURCE%"=="" set "UFO50_SOURCE=%~dp0ufo50"
+if not "%UFO50_SOURCE:~-1%"=="\" set "UFO50_SOURCE=%UFO50_SOURCE%\"
+
+set "WRAPPER_APK=%UFO50_WRAPPER_APK%"
+if "%WRAPPER_APK%"=="" set "WRAPPER_APK=%~dp0base\AndroidWrapper2024.1400.4.968_VM_debug_gamepad_hotplug.apk"
 
 REM Make sure that we actually have game files first
-if not exist ".\ufo50\data.win" (
-	echo Place your UFO 50 game files in the ufo50 folder first!
+if not exist "%UFO50_SOURCE%data.win" (
+	echo Place your UFO 50 game files in "%UFO50_SOURCE%" first, pass the path as the first argument, or set UFO50_SOURCE.
+	pause
+	exit /b 1
+)
+
+if not exist "%UFO50_SOURCE%options.ini" (
+	echo ERROR: Missing "%UFO50_SOURCE%options.ini"
+	pause
+	exit /b 1
+)
+
+if not exist "%WRAPPER_APK%" (
+	echo ERROR: Missing wrapper APK: "%WRAPPER_APK%"
 	pause
 	exit /b 1
 )
 
 : PREP
 REM Clean up from any previous runs
-@del UFO50Wrapper.apk
-@del com.unofficial.ufo50.zip
-@rmdir /s /q assets
+@del UFO50Wrapper.apk 2>nul
+@del com.unofficial.ufo50.zip 2>nul
+@rmdir /s /q assets 2>nul
 @mkdir assets
 
-REM Copy required assets
-echo Preparing assets...
-robocopy /e /nfl .\ufo50\ext .\assets\ext
-robocopy /e /nfl .\ufo50\Textures .\assets\Textures
-copy .\ufo50\*.dat .\assets\
-copy .\ufo50\options.ini .\assets\
-copy .\ufo50\data.win .\assets\game.droid
-copy .\base\AndroidWrapper2024.8.0.216_VM_debug.apk UFO50Wrapper.apk
+REM Copy required assets. Keep this discovery-based so new UFO 50 releases work when
+REM texture groups, audio groups, fonts, or localization files are added/removed.
+echo Preparing assets from "%UFO50_SOURCE%"...
+if exist "%UFO50_SOURCE%ext\" robocopy /e /nfl "%UFO50_SOURCE%ext" ".\assets\ext"
+if exist "%UFO50_SOURCE%Textures\" robocopy /e /nfl "%UFO50_SOURCE%Textures" ".\assets\Textures"
+if exist "%UFO50_SOURCE%fonts\" robocopy /e /nfl "%UFO50_SOURCE%fonts" ".\assets\fonts"
+copy "%UFO50_SOURCE%*.dat" ".\assets\"
+copy "%UFO50_SOURCE%options.ini" ".\assets\"
+copy "%UFO50_SOURCE%data.win" ".\assets\game.droid"
+copy "%WRAPPER_APK%" UFO50Wrapper.apk
+
+REM Normalize staged assets to lowercase paths because Android APK assets are case-sensitive
+REM and the GameMaker runtime lowercases datafile paths.
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$root=(Resolve-Path '.\assets').Path; $tmp=(Resolve-Path '.').Path+'\assets.lowercase'; if(Test-Path $tmp){Remove-Item -Recurse -Force $tmp}; New-Item -ItemType Directory -Path $tmp | Out-Null; Get-ChildItem -LiteralPath $root -Recurse -File | ForEach-Object { $rel=$_.FullName.Substring($root.Length+1).ToLowerInvariant(); $dest=Join-Path $tmp $rel; New-Item -ItemType Directory -Force -Path (Split-Path $dest) | Out-Null; Copy-Item -LiteralPath $_.FullName -Destination $dest }; Remove-Item -Recurse -Force $root; Rename-Item -LiteralPath $tmp -NewName 'assets'"
+if errorlevel 1 exit /b !errorlevel!
+
+REM Some current PC builds have trailing bytes after the GameMaker FORM chunk.
+REM The Android runner rejects those with "unexpected size", so trim game.droid
+REM to the FORM header size when needed.
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$p='.\assets\game.droid'; $fs=[System.IO.File]::Open($p,[System.IO.FileMode]::Open,[System.IO.FileAccess]::ReadWrite); try { $b=New-Object byte[] 8; [void]$fs.Read($b,0,8); if ($b[0] -ne 70 -or $b[1] -ne 79 -or $b[2] -ne 82 -or $b[3] -ne 77) { throw 'assets/game.droid is not a GameMaker FORM file' }; $expected=[BitConverter]::ToUInt32($b,4)+8; $actual=$fs.Length; if ($actual -gt $expected) { Write-Host "Trimming game.droid from $actual to FORM size $expected bytes"; $fs.SetLength($expected) } elseif ($actual -lt $expected) { throw "game.droid is smaller than FORM header size ($actual < $expected)" } } finally { $fs.Close() }"
+if errorlevel 1 exit /b !errorlevel!
+
+REM Patch Steamworks extension metadata so calls route to com.unofficial.ufo50.Steamworks.
+set "UTMT_CLI=%UTMT_CLI%"
+if "%UTMT_CLI%"=="" set "UTMT_CLI=%CD%\bin\utmt\UndertaleModCli.exe"
+if not exist "%UTMT_CLI%" (
+  echo Downloading UndertaleModCli...
+  if exist ".\bin\utmt\" rmdir /s /q ".\bin\utmt"
+  mkdir ".\bin\utmt"
+  powershell -NoProfile -ExecutionPolicy Bypass -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri 'https://github.com/UnderminersTeam/UndertaleModTool/releases/download/0.9.1.0/UTMT_CLI_v0.9.1.0-Windows.zip' -OutFile '.\utmt.zip'; Expand-Archive '.\utmt.zip' -DestinationPath '.\bin\utmt'"
+  if errorlevel 1 exit /b !errorlevel!
+  del ".\utmt.zip"
+)
+echo Patching Steamworks extension metadata for Android...
+"%UTMT_CLI%" load .\assets\game.droid -s .\scripts\patch_ufo50_android.csx -o .\assets\game.droid.patched
+if errorlevel 1 exit /b !errorlevel!
+move /y .\assets\game.droid.patched .\assets\game.droid
 
 REM Clean wrapper apk
+REM The base wrapper contains placeholder game.droid/options.ini; replace them.
 echo Preparing wrapper...
 .\bin\aapt remove -f -v UFO50Wrapper.apk assets/options.ini
 .\bin\aapt remove -f -v UFO50Wrapper.apk assets/game.droid
@@ -52,63 +102,17 @@ del ".\jdk.zip"
 : PACK
 REM Add game assets to base wrapper APK
 echo Building wrapper...
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/audiogroup1.dat assets/audiogroup2.dat assets/audiogroup3.dat assets/audiogroup4.dat assets/audiogroup5.dat assets/audiogroup6.dat assets/audiogroup7.dat assets/audiogroup8.dat assets/audiogroup9.dat
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/audiogroup10.dat assets/audiogroup11.dat assets/audiogroup12.dat assets/audiogroup13.dat assets/audiogroup14.dat assets/audiogroup15.dat assets/audiogroup16.dat assets/audiogroup17.dat assets/audiogroup18.dat assets/audiogroup19.dat
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/audiogroup20.dat assets/audiogroup21.dat assets/audiogroup22.dat assets/audiogroup23.dat assets/audiogroup24.dat assets/audiogroup25.dat assets/audiogroup26.dat assets/audiogroup27.dat assets/audiogroup28.dat assets/audiogroup29.dat
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/audiogroup30.dat assets/audiogroup31.dat assets/audiogroup32.dat assets/audiogroup33.dat assets/audiogroup34.dat assets/audiogroup35.dat assets/audiogroup36.dat assets/audiogroup37.dat assets/audiogroup38.dat assets/audiogroup39.dat
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/audiogroup40.dat assets/audiogroup41.dat assets/audiogroup43.dat assets/audiogroup44.dat assets/audiogroup45.dat assets/audiogroup46.dat assets/audiogroup47.dat assets/audiogroup48.dat assets/audiogroup49.dat
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/audiogroup50.dat assets/audiogroup51.dat assets/audiogroup52.dat assets/audiogroup53.dat
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/ENGLISH/0_Text.json assets/ext/ENGLISH/1_Text.json assets/ext/ENGLISH/2_Text.json assets/ext/ENGLISH/3_Text.json assets/ext/ENGLISH/4_Text.json assets/ext/ENGLISH/5_Text.json assets/ext/ENGLISH/6_Text.json assets/ext/ENGLISH/7_Text.json assets/ext/ENGLISH/8_Text.json assets/ext/ENGLISH/9_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/ENGLISH/10_Text.json assets/ext/ENGLISH/11_Text.json assets/ext/ENGLISH/12_Text.json assets/ext/ENGLISH/13_Text.json assets/ext/ENGLISH/14_Text.json assets/ext/ENGLISH/15_Text.json assets/ext/ENGLISH/16_Text.json assets/ext/ENGLISH/17_Text.json assets/ext/ENGLISH/18_Text.json assets/ext/ENGLISH/19_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/ENGLISH/20_Text.json assets/ext/ENGLISH/21_Text.json assets/ext/ENGLISH/22_Text.json assets/ext/ENGLISH/23_Text.json assets/ext/ENGLISH/24_Text.json assets/ext/ENGLISH/25_Text.json assets/ext/ENGLISH/26_Text.json assets/ext/ENGLISH/27_Text.json assets/ext/ENGLISH/28_Text.json assets/ext/ENGLISH/29_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/ENGLISH/30_Text.json assets/ext/ENGLISH/31_Text.json assets/ext/ENGLISH/32_Text.json assets/ext/ENGLISH/33_Text.json assets/ext/ENGLISH/34_Text.json assets/ext/ENGLISH/35_Text.json assets/ext/ENGLISH/36_Text.json assets/ext/ENGLISH/37_Text.json assets/ext/ENGLISH/38_Text.json assets/ext/ENGLISH/39_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/ENGLISH/40_Text.json assets/ext/ENGLISH/41_Text.json assets/ext/ENGLISH/42_Text.json assets/ext/ENGLISH/43_Text.json assets/ext/ENGLISH/44_Text.json assets/ext/ENGLISH/45_Text.json assets/ext/ENGLISH/46_Text.json assets/ext/ENGLISH/47_Text.json assets/ext/ENGLISH/48_Text.json assets/ext/ENGLISH/49_Text.json assets/ext/ENGLISH/50_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/FRENCH/0_Text.json assets/ext/FRENCH/1_Text.json assets/ext/FRENCH/2_Text.json assets/ext/FRENCH/3_Text.json assets/ext/FRENCH/4_Text.json assets/ext/FRENCH/5_Text.json assets/ext/FRENCH/6_Text.json assets/ext/FRENCH/7_Text.json assets/ext/FRENCH/8_Text.json assets/ext/FRENCH/9_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/FRENCH/10_Text.json assets/ext/FRENCH/11_Text.json assets/ext/FRENCH/12_Text.json assets/ext/FRENCH/13_Text.json assets/ext/FRENCH/14_Text.json assets/ext/FRENCH/15_Text.json assets/ext/FRENCH/16_Text.json assets/ext/FRENCH/17_Text.json assets/ext/FRENCH/18_Text.json assets/ext/FRENCH/19_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/FRENCH/20_Text.json assets/ext/FRENCH/21_Text.json assets/ext/FRENCH/22_Text.json assets/ext/FRENCH/23_Text.json assets/ext/FRENCH/24_Text.json assets/ext/FRENCH/25_Text.json assets/ext/FRENCH/26_Text.json assets/ext/FRENCH/27_Text.json assets/ext/FRENCH/28_Text.json assets/ext/FRENCH/29_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/FRENCH/30_Text.json assets/ext/FRENCH/31_Text.json assets/ext/FRENCH/32_Text.json assets/ext/FRENCH/33_Text.json assets/ext/FRENCH/34_Text.json assets/ext/FRENCH/35_Text.json assets/ext/FRENCH/36_Text.json assets/ext/FRENCH/37_Text.json assets/ext/FRENCH/38_Text.json assets/ext/FRENCH/39_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/FRENCH/40_Text.json assets/ext/FRENCH/41_Text.json assets/ext/FRENCH/42_Text.json assets/ext/FRENCH/43_Text.json assets/ext/FRENCH/44_Text.json assets/ext/FRENCH/45_Text.json assets/ext/FRENCH/46_Text.json assets/ext/FRENCH/47_Text.json assets/ext/FRENCH/48_Text.json assets/ext/FRENCH/49_Text.json assets/ext/FRENCH/50_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/GERMAN/0_Text.json assets/ext/GERMAN/1_Text.json assets/ext/GERMAN/2_Text.json assets/ext/GERMAN/3_Text.json assets/ext/GERMAN/4_Text.json assets/ext/GERMAN/5_Text.json assets/ext/GERMAN/6_Text.json assets/ext/GERMAN/7_Text.json assets/ext/GERMAN/8_Text.json assets/ext/GERMAN/9_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/GERMAN/10_Text.json assets/ext/GERMAN/11_Text.json assets/ext/GERMAN/12_Text.json assets/ext/GERMAN/13_Text.json assets/ext/GERMAN/14_Text.json assets/ext/GERMAN/15_Text.json assets/ext/GERMAN/16_Text.json assets/ext/GERMAN/17_Text.json assets/ext/GERMAN/18_Text.json assets/ext/GERMAN/19_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/GERMAN/20_Text.json assets/ext/GERMAN/21_Text.json assets/ext/GERMAN/22_Text.json assets/ext/GERMAN/23_Text.json assets/ext/GERMAN/24_Text.json assets/ext/GERMAN/25_Text.json assets/ext/GERMAN/26_Text.json assets/ext/GERMAN/27_Text.json assets/ext/GERMAN/28_Text.json assets/ext/GERMAN/29_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/GERMAN/30_Text.json assets/ext/GERMAN/31_Text.json assets/ext/GERMAN/32_Text.json assets/ext/GERMAN/33_Text.json assets/ext/GERMAN/34_Text.json assets/ext/GERMAN/35_Text.json assets/ext/GERMAN/36_Text.json assets/ext/GERMAN/37_Text.json assets/ext/GERMAN/38_Text.json assets/ext/GERMAN/39_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/GERMAN/40_Text.json assets/ext/GERMAN/41_Text.json assets/ext/GERMAN/42_Text.json assets/ext/GERMAN/43_Text.json assets/ext/GERMAN/44_Text.json assets/ext/GERMAN/45_Text.json assets/ext/GERMAN/46_Text.json assets/ext/GERMAN/47_Text.json assets/ext/GERMAN/48_Text.json assets/ext/GERMAN/49_Text.json assets/ext/GERMAN/50_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/ITALIAN/0_Text.json assets/ext/ITALIAN/1_Text.json assets/ext/ITALIAN/2_Text.json assets/ext/ITALIAN/3_Text.json assets/ext/ITALIAN/4_Text.json assets/ext/ITALIAN/5_Text.json assets/ext/ITALIAN/6_Text.json assets/ext/ITALIAN/7_Text.json assets/ext/ITALIAN/8_Text.json assets/ext/ITALIAN/9_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/ITALIAN/10_Text.json assets/ext/ITALIAN/11_Text.json assets/ext/ITALIAN/12_Text.json assets/ext/ITALIAN/13_Text.json assets/ext/ITALIAN/14_Text.json assets/ext/ITALIAN/15_Text.json assets/ext/ITALIAN/16_Text.json assets/ext/ITALIAN/17_Text.json assets/ext/ITALIAN/18_Text.json assets/ext/ITALIAN/19_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/ITALIAN/20_Text.json assets/ext/ITALIAN/21_Text.json assets/ext/ITALIAN/22_Text.json assets/ext/ITALIAN/23_Text.json assets/ext/ITALIAN/24_Text.json assets/ext/ITALIAN/25_Text.json assets/ext/ITALIAN/26_Text.json assets/ext/ITALIAN/27_Text.json assets/ext/ITALIAN/28_Text.json assets/ext/ITALIAN/29_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/ITALIAN/30_Text.json assets/ext/ITALIAN/31_Text.json assets/ext/ITALIAN/32_Text.json assets/ext/ITALIAN/33_Text.json assets/ext/ITALIAN/34_Text.json assets/ext/ITALIAN/35_Text.json assets/ext/ITALIAN/36_Text.json assets/ext/ITALIAN/37_Text.json assets/ext/ITALIAN/38_Text.json assets/ext/ITALIAN/39_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/ITALIAN/40_Text.json assets/ext/ITALIAN/41_Text.json assets/ext/ITALIAN/42_Text.json assets/ext/ITALIAN/43_Text.json assets/ext/ITALIAN/44_Text.json assets/ext/ITALIAN/45_Text.json assets/ext/ITALIAN/46_Text.json assets/ext/ITALIAN/47_Text.json assets/ext/ITALIAN/48_Text.json assets/ext/ITALIAN/49_Text.json assets/ext/ITALIAN/50_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/PORTUGUESE/0_Text.json assets/ext/PORTUGUESE/1_Text.json assets/ext/PORTUGUESE/2_Text.json assets/ext/PORTUGUESE/3_Text.json assets/ext/PORTUGUESE/4_Text.json assets/ext/PORTUGUESE/5_Text.json assets/ext/PORTUGUESE/6_Text.json assets/ext/PORTUGUESE/7_Text.json assets/ext/PORTUGUESE/8_Text.json assets/ext/PORTUGUESE/9_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/PORTUGUESE/10_Text.json assets/ext/PORTUGUESE/11_Text.json assets/ext/PORTUGUESE/12_Text.json assets/ext/PORTUGUESE/13_Text.json assets/ext/PORTUGUESE/14_Text.json assets/ext/PORTUGUESE/15_Text.json assets/ext/PORTUGUESE/16_Text.json assets/ext/PORTUGUESE/17_Text.json assets/ext/PORTUGUESE/18_Text.json assets/ext/PORTUGUESE/19_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/PORTUGUESE/20_Text.json assets/ext/PORTUGUESE/21_Text.json assets/ext/PORTUGUESE/22_Text.json assets/ext/PORTUGUESE/23_Text.json assets/ext/PORTUGUESE/24_Text.json assets/ext/PORTUGUESE/25_Text.json assets/ext/PORTUGUESE/26_Text.json assets/ext/PORTUGUESE/27_Text.json assets/ext/PORTUGUESE/28_Text.json assets/ext/PORTUGUESE/29_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/PORTUGUESE/30_Text.json assets/ext/PORTUGUESE/31_Text.json assets/ext/PORTUGUESE/32_Text.json assets/ext/PORTUGUESE/33_Text.json assets/ext/PORTUGUESE/34_Text.json assets/ext/PORTUGUESE/35_Text.json assets/ext/PORTUGUESE/36_Text.json assets/ext/PORTUGUESE/37_Text.json assets/ext/PORTUGUESE/38_Text.json assets/ext/PORTUGUESE/39_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/PORTUGUESE/40_Text.json assets/ext/PORTUGUESE/41_Text.json assets/ext/PORTUGUESE/42_Text.json assets/ext/PORTUGUESE/43_Text.json assets/ext/PORTUGUESE/44_Text.json assets/ext/PORTUGUESE/45_Text.json assets/ext/PORTUGUESE/46_Text.json assets/ext/PORTUGUESE/47_Text.json assets/ext/PORTUGUESE/48_Text.json assets/ext/PORTUGUESE/49_Text.json assets/ext/PORTUGUESE/50_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/SPANISH/0_Text.json assets/ext/SPANISH/1_Text.json assets/ext/SPANISH/2_Text.json assets/ext/SPANISH/3_Text.json assets/ext/SPANISH/4_Text.json assets/ext/SPANISH/5_Text.json assets/ext/SPANISH/6_Text.json assets/ext/SPANISH/7_Text.json assets/ext/SPANISH/8_Text.json assets/ext/SPANISH/9_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/SPANISH/10_Text.json assets/ext/SPANISH/11_Text.json assets/ext/SPANISH/12_Text.json assets/ext/SPANISH/13_Text.json assets/ext/SPANISH/14_Text.json assets/ext/SPANISH/15_Text.json assets/ext/SPANISH/16_Text.json assets/ext/SPANISH/17_Text.json assets/ext/SPANISH/18_Text.json assets/ext/SPANISH/19_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/SPANISH/20_Text.json assets/ext/SPANISH/21_Text.json assets/ext/SPANISH/22_Text.json assets/ext/SPANISH/23_Text.json assets/ext/SPANISH/24_Text.json assets/ext/SPANISH/25_Text.json assets/ext/SPANISH/26_Text.json assets/ext/SPANISH/27_Text.json assets/ext/SPANISH/28_Text.json assets/ext/SPANISH/29_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/SPANISH/30_Text.json assets/ext/SPANISH/31_Text.json assets/ext/SPANISH/32_Text.json assets/ext/SPANISH/33_Text.json assets/ext/SPANISH/34_Text.json assets/ext/SPANISH/35_Text.json assets/ext/SPANISH/36_Text.json assets/ext/SPANISH/37_Text.json assets/ext/SPANISH/38_Text.json assets/ext/SPANISH/39_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/ext/SPANISH/40_Text.json assets/ext/SPANISH/41_Text.json assets/ext/SPANISH/42_Text.json assets/ext/SPANISH/43_Text.json assets/ext/SPANISH/44_Text.json assets/ext/SPANISH/45_Text.json assets/ext/SPANISH/46_Text.json assets/ext/SPANISH/47_Text.json assets/ext/SPANISH/48_Text.json assets/ext/SPANISH/49_Text.json assets/ext/SPANISH/50_Text.json
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/Textures/texturegroup00_library_0.yytex assets/Textures/texturegroup00_shared_0.yytex
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/Textures/texturegroup01_0.yytex assets/Textures/texturegroup02_0.yytex assets/Textures/texturegroup03_0.yytex assets/Textures/texturegroup04_0.yytex assets/Textures/texturegroup05_0.yytex assets/Textures/texturegroup06_0.yytex
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/Textures/texturegroup07_0.yytex assets/Textures/texturegroup07_1.yytex assets/Textures/texturegroup07_2.yytex assets/Textures/texturegroup07_3.yytex assets/Textures/texturegroup07_4.yytex
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/Textures/texturegroup07_5.yytex assets/Textures/texturegroup07_6.yytex assets/Textures/texturegroup07_7.yytex assets/Textures/texturegroup07_8.yytex assets/Textures/texturegroup07_9.yytex
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/Textures/texturegroup07_10.yytex assets/Textures/texturegroup07_11.yytex assets/Textures/texturegroup07_12.yytex assets/Textures/texturegroup07_13.yytex assets/Textures/texturegroup07_14.yytex assets/Textures/texturegroup07_15.yytex
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/Textures/texturegroup08_0.yytex assets/Textures/texturegroup09_0.yytex assets/Textures/texturegroup09_1.yytex assets/Textures/texturegroup10_0.yytex assets/Textures/texturegroup11_0.yytex assets/Textures/texturegroup12_0.yytex assets/Textures/texturegroup12_1.yytex
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/Textures/texturegroup13_0.yytex assets/Textures/texturegroup14_0.yytex assets/Textures/texturegroup15_0.yytex assets/Textures/texturegroup16_0.yytex assets/Textures/texturegroup17_0.yytex assets/Textures/texturegroup18_0.yytex assets/Textures/texturegroup19_0.yytex
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/Textures/texturegroup20_0.yytex assets/Textures/texturegroup21_0.yytex assets/Textures/texturegroup22_0.yytex assets/Textures/texturegroup23_0.yytex assets/Textures/texturegroup24_0.yytex assets/Textures/texturegroup25_0.yytex
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/Textures/texturegroup26_0.yytex assets/Textures/texturegroup27_0.yytex assets/Textures/texturegroup28_0.yytex assets/Textures/texturegroup29_0.yytex assets/Textures/texturegroup30_0.yytex assets/Textures/texturegroup31_0.yytex
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/Textures/texturegroup32_0.yytex assets/Textures/texturegroup32_1.yytex assets/Textures/texturegroup32_2.yytex assets/Textures/texturegroup32_3.yytex assets/Textures/texturegroup32_4.yytex assets/Textures/texturegroup32_5.yytex
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/Textures/texturegroup32_6.yytex assets/Textures/texturegroup32_7.yytex assets/Textures/texturegroup32_8.yytex assets/Textures/texturegroup32_9.yytex assets/Textures/texturegroup32_10.yytex assets/Textures/texturegroup32_11.yytex
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/Textures/texturegroup32_12.yytex assets/Textures/texturegroup32_13.yytex assets/Textures/texturegroup32_14.yytex assets/Textures/texturegroup32_15.yytex assets/Textures/texturegroup32_16.yytex assets/Textures/texturegroup32_17.yytex assets/Textures/texturegroup32_18.yytex
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/Textures/texturegroup32_19.yytex assets/Textures/texturegroup32_20.yytex assets/Textures/texturegroup32_21.yytex assets/Textures/texturegroup32_22.yytex assets/Textures/texturegroup32_23.yytex assets/Textures/texturegroup32_24.yytex
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/Textures/texturegroup33_0.yytex assets/Textures/texturegroup33_1.yytex assets/Textures/texturegroup34_0.yytex assets/Textures/texturegroup35_0.yytex assets/Textures/texturegroup35_1.yytex assets/Textures/texturegroup35_2.yytex
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/Textures/texturegroup35_3.yytex assets/Textures/texturegroup35_4.yytex assets/Textures/texturegroup35_5.yytex assets/Textures/texturegroup36_0.yytex assets/Textures/texturegroup37_0.yytex assets/Textures/texturegroup38_0.yytex
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/Textures/texturegroup39_0.yytex assets/Textures/texturegroup39_1.yytex assets/Textures/texturegroup39_2.yytex assets/Textures/texturegroup39_3.yytex assets/Textures/texturegroup40_0.yytex assets/Textures/texturegroup41_0.yytex
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/Textures/texturegroup41_1.yytex assets/Textures/texturegroup41_2.yytex assets/Textures/texturegroup41_3.yytex assets/Textures/texturegroup41_4.yytex assets/Textures/texturegroup41_5.yytex assets/Textures/texturegroup41_6.yytex
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/Textures/texturegroup41_7.yytex assets/Textures/texturegroup42_0.yytex assets/Textures/texturegroup43_0.yytex assets/Textures/texturegroup44_0.yytex assets/Textures/texturegroup45_0.yytex assets/Textures/texturegroup45_1.yytex
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/Textures/texturegroup46_0.yytex assets/Textures/texturegroup47_0.yytex assets/Textures/texturegroup48_0.yytex assets/Textures/texturegroup49_0.yytex assets/Textures/texturegroup50_0.yytex assets/Textures/texturegroup51_0.yytex
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/options.ini
-.\bin\aapt add -f -v UFO50Wrapper.apk assets/game.droid
+for /r assets %%F in (*) do (
+	set "asset=%%F"
+	set "asset=!asset:%CD%\=!"
+	set "asset=!asset:\=/!"
+	.\bin\aapt add -f -v UFO50Wrapper.apk "!asset!"
+	if errorlevel 1 exit /b !errorlevel!
+)
+
+REM Store externally loaded localization/font files without compression.
+powershell -NoProfile -ExecutionPolicy Bypass -Command "Add-Type -AssemblyName System.IO.Compression.FileSystem; $apk='UFO50Wrapper.apk'; $tmp='UFO50Wrapper.apk.tmp'; if(Test-Path $tmp){Remove-Item $tmp}; $zin=[IO.Compression.ZipFile]::OpenRead($apk); $zout=[IO.Compression.ZipFile]::Open($tmp,[IO.Compression.ZipArchiveMode]::Create); try { foreach($entry in $zin.Entries){ $method=[IO.Compression.CompressionLevel]::Optimal; if($entry.FullName.StartsWith('assets/ext/') -or $entry.FullName.StartsWith('assets/fonts/')){ $method=[IO.Compression.CompressionLevel]::NoCompression }; $new=$zout.CreateEntry($entry.FullName,$method); $src=$entry.Open(); $dst=$new.Open(); try { $src.CopyTo($dst) } finally { $dst.Dispose(); $src.Dispose() } } } finally { $zout.Dispose(); $zin.Dispose() }; Move-Item -Force $tmp $apk"
+if errorlevel 1 exit /b !errorlevel!
 
 : BUILD
 REM Zipalign and sign APK
@@ -120,9 +124,9 @@ echo Building APK...
 REM Clean up
 echo Cleaning up...
 del com.unofficial.ufo50.zipalign.apk
-del com.unofficial.ufo50.apk.idsig
+del com.unofficial.ufo50.apk.idsig 2>nul
 del UFO50Wrapper.apk
 rmdir /s /q assets
 
-echo Done! Have fun.
+echo Done! Built com.unofficial.ufo50.apk. Have fun.
 pause

--- a/scripts/patch_ufo50_android.csx
+++ b/scripts/patch_ufo50_android.csx
@@ -1,0 +1,11 @@
+using UndertaleModLib.Models;
+using System;
+
+foreach (var ext in Data.Extensions)
+{
+    if (ext.Name?.Content == "Steamworks")
+    {
+        ext.ClassName = Data.Strings.MakeString("Steamworks");
+        Console.WriteLine($"Set Steamworks extension class to {ext.ClassName.Content}");
+    }
+}

--- a/upload_saves_macos.sh
+++ b/upload_saves_macos.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+./bin/adb-osx devices | grep device | grep -v List | while read line ; do
+	devid=`echo $line | cut -d ' ' -f 1`
+	./bin/adb-osx -s $devid shell "run-as com.unofficial.ufo50 mkdir /sdcard/UFO50Backup"
+	./bin/adb-osx -s $devid push ./save/save1.ufo /sdcard/UFO50Backup/
+	./bin/adb-osx -s $devid push ./save/save2.ufo /sdcard/UFO50Backup/
+	./bin/adb-osx -s $devid push ./save/save3.ufo /sdcard/UFO50Backup/
+	./bin/adb-osx -s $devid push ./save/account.ufo /sdcard/UFO50Backup/
+	./bin/adb-osx -s $devid shell "run-as com.unofficial.ufo50 cp -f /sdcard/UFO50Backup/save1.ufo /data/data/com.unofficial.ufo50/files/"
+	./bin/adb-osx -s $devid shell "run-as com.unofficial.ufo50 cp -f /sdcard/UFO50Backup/save2.ufo /data/data/com.unofficial.ufo50/files/"
+	./bin/adb-osx -s $devid shell "run-as com.unofficial.ufo50 cp -f /sdcard/UFO50Backup/save3.ufo /data/data/com.unofficial.ufo50/files/"
+	./bin/adb-osx -s $devid shell "run-as com.unofficial.ufo50 cp -f /sdcard/UFO50Backup/account.ufo /data/data/com.unofficial.ufo50/files/"
+done


### PR DESCRIPTION
## Summary
- update build scripts for current UFO 50 Steam depot layouts by discovering audio, texture, font, and localization assets dynamically
- normalize staged asset paths to lowercase and store externally loaded localization/font files uncompressed so Android GameMaker can resolve them
- trim trailing bytes after the GameMaker `FORM` chunk before packaging `game.droid`
- patch Steamworks extension metadata during builds with UndertaleModCli so Steam calls route to the Android stub
- add a GameMaker 2024.1400.4.968 Android wrapper patched for Bluetooth controller hotplug detection

## Test plan
- `bash -n build_linux`
- `bash -n build_macos.sh`
- `./build_linux /home/eran/.local/share/Steam/ubuntu12_32/steamapps/content/app_1147860/depot_1147861`
- `./bin/java/bin/java -jar ./bin/apksigner.jar verify --verbose com.unofficial.ufo50.apk`
- `./bin/zipalign -c -p 4 com.unofficial.ufo50.apk`
- Installed and launched on Android via adb; verified UFO 50 reaches gameplay with no crash log
